### PR TITLE
Update analyzer nuget references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,10 +4,10 @@
     See also: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#search-scope
     -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.8.55" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.9.60" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" />
-        <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1" />
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" />
 
         <!--
         Additional settings for specific rules (e.g. SA1200 specify namespaces must be placed correctly, the json file then defines what "correctly" means)


### PR DESCRIPTION
Updates the nuget packages to newest version.
For StyleCop.Analyzers we move to prerelease to get C# 9.0 support.