### PR TITLE
Discover internal enumeration values

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/EnumerationType.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/EnumerationType.cs
@@ -69,7 +69,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.SeedWork
         public static IEnumerable<T> GetAll<T>()
                    where T : EnumerationType
         {
-            var fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly);
+            var fields = typeof(T).GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly);
 
             return fields.Select(f => f.GetValue(null)).Cast<T>();
         }


### PR DESCRIPTION
## Description

If an enumeration class is defined as internal the `GetAll<T>()` method does not find any of the fields.

E.g.:
```csharp
    internal sealed class DocumentTypes : EnumerationType
    {
        internal static readonly DocumentTypes Word = new(1, nameof(Word));
        internal static readonly DocumentTypes Excel = new(2, nameof(Excel));
        internal static readonly DocumentTypes PowerPoint = new(3, nameof(PowerPoint));
        internal static readonly DocumentTypes OneNote = new(4, nameof(OneNote));
        internal static readonly DocumentTypes Lens = new(5, nameof(Lens));

        private DocumentTypes(int id, string name)
            : base(id, name)
        {
        }
    }
```

would make this test fail:

``` csharp
var expected = DocumentTypes.Lens;
var actual = EnumerationType.FromName<DocumentTypes>("Lens");

Assert.Equal(expected, actual);
```

If this PR is merged the test-case above would pass.