### PR TITLE
Set C# lang version explicitly to 9.0

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.csproj
@@ -18,6 +18,7 @@ limitations under the License.
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
@@ -18,6 +18,7 @@ limitations under the License.
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
@@ -17,6 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
@@ -17,6 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -17,6 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
@@ -50,7 +51,7 @@ limitations under the License.
       <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
       <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
     </ItemGroup>
-    
+
     <ItemGroup>
       <Protobuf Include="**/*.proto">
         <GrpcServices>None</GrpcServices>
@@ -61,7 +62,7 @@ limitations under the License.
         <Generator>MSBuild:Compile</Generator>
       </Protobuf>
     </ItemGroup>
-    
+
     <ItemGroup>
       <ProjectReference Include="..\Energinet.DataHub.MeteringPoints.Application\Energinet.DataHub.MeteringPoints.Application.csproj" />
     </ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-
+      <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
         <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     </PropertyGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
-
+      <LangVersion>9.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 


### PR DESCRIPTION
Set lang version to 9.0 on all projects to avoid build errors (I.e. <Nullable>enable</Nullable> not working)

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

I was getting errors on my machine like this one. The fix was to specify the C# lang version in all csproj files.
![image](https://user-images.githubusercontent.com/22943367/118927426-110d5a80-b942-11eb-9fae-13ee199a175b.png)