### PR TITLE
Enrich metering point with attributes

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
@@ -16,6 +16,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using MediatR;
 
 namespace Energinet.DataHub.MeteringPoints.Application
@@ -31,7 +32,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
 
         public Task<CreateMeteringPointResult> Handle(CreateMeteringPoint request, CancellationToken cancellationToken)
         {
-            var meteringPoint = new MeteringPoint(GsrnNumber.Create(request.GsrnNumber));
+            var meteringPoint = new MeteringPoint(MeteringPointId.New(), GsrnNumber.Create(request.GsrnNumber), EnumerationType.FromName<MeteringPointType>(request.TypeOfMeteringPoint));
             _meteringPointRepository.Add(meteringPoint);
             return Task.FromResult(new CreateMeteringPointResult());
         }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
@@ -13,15 +13,40 @@
 // limitations under the License.
 
 using System;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
-    public class MeteringPoint
+    //TODO:REMEMBER REMOVE THIS WHEN VALUE OBJECTS ARE IMPLEMENTED
+    #pragma warning disable
+    public class MeteringPoint : AggregateRootBase
     {
-        public MeteringPoint(GsrnNumber gsrnNumber)
+        //TODO: Implement relevant value objects
+        private MeteringPointType _typeOfMeteringPoint;
+        private string _subTypeOfMeteringPoint;
+        private string _meterReadingOccurrence;
+        private int _maximumCurrent;
+        private int _maximumPower;
+        private string _meteringGridArea;
+        private string _powerPlant;
+        private string _locationDescription;
+        private string _productType;
+        private string _parentRelatedMeteringPoint;
+        private string _settlementMethod;
+        private string _unitType;
+        private string _disconnectionType;
+        private string _occurenceDate;
+        private string _meterNumber;
+
+        public MeteringPoint(MeteringPointId meteringPointId, GsrnNumber gsrnNumber, MeteringPointType typeOfMeteringPoint)
         {
+            Id = meteringPointId ?? throw new ArgumentNullException(nameof(meteringPointId));
             GsrnNumber = gsrnNumber ?? throw new ArgumentNullException(nameof(gsrnNumber));
+            _typeOfMeteringPoint = typeOfMeteringPoint ?? throw new ArgumentNullException(nameof(typeOfMeteringPoint));
+            AddDomainEvent(new MeteringPointCreated(meteringPointId, GsrnNumber));
         }
+
+        public MeteringPointId Id { get; }
 
         public GsrnNumber GsrnNumber { get; }
     }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointCreated.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointCreated.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
+{
+    public class MeteringPointCreated : DomainEventBase
+    {
+        public MeteringPointCreated(MeteringPointId meteringPointId, GsrnNumber gsrnNumber)
+        {
+            MeteringPointId = meteringPointId;
+            GsrnNumber = gsrnNumber;
+        }
+
+        public MeteringPointId MeteringPointId { get; }
+
+        public GsrnNumber GsrnNumber { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointId.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointId.cs
@@ -1,0 +1,34 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
+{
+    public class MeteringPointId : ValueObject
+    {
+        public MeteringPointId(Guid value)
+        {
+            Value = value;
+        }
+
+        public Guid Value { get; }
+
+        public static MeteringPointId New()
+        {
+            return new MeteringPointId(Guid.NewGuid());
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointType.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPointType.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
+{
+    public class MeteringPointType : EnumerationType
+    {
+        public static readonly MeteringPointType Consumption = new MeteringPointType(0, nameof(Consumption));
+        public static readonly MeteringPointType Production = new MeteringPointType(1, nameof(Production));
+        public static readonly MeteringPointType Exchange = new MeteringPointType(2, nameof(Exchange));
+
+        private MeteringPointType(int id, string name)
+            : base(id, name)
+        {
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/PhysicalState.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/PhysicalState.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
+{
+    public class PhysicalState : EnumerationType
+    {
+        public static readonly PhysicalState New = new PhysicalState(0, nameof(New));
+        public static readonly PhysicalState Connected = new PhysicalState(1, nameof(Connected));
+        public static readonly PhysicalState Disconnected = new PhysicalState(2, nameof(Disconnected));
+        public static readonly PhysicalState ClosedDown = new PhysicalState(3, nameof(ClosedDown));
+
+        private PhysicalState(int id, string name)
+            : base(id, name)
+        {
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -39,7 +39,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
         {
             var request = new CreateMeteringPoint(
                 SampleData.GsrnNumber,
-                "Fake",
+                SampleData.TypeOfMeteringPoint,
                 "Fake",
                 "Fake",
                 0,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -38,6 +38,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
         public async Task Create_WhenNoValidationErrors_IsSuccessful()
         {
             var request = new CreateMeteringPoint(
+                new Address(),
                 SampleData.GsrnNumber,
                 SampleData.TypeOfMeteringPoint,
                 "Fake",
@@ -48,7 +49,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
                 "FAke",
                 "FAke",
                 "Fake",
-                new Address(),
+
                 "Fake",
                 "Fake",
                 "Fake",

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/MeteringPointTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/MeteringPointTests.cs
@@ -12,16 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Xunit;
+using Xunit.Categories;
 
-namespace Energinet.DataHub.MeteringPoints.IntegrationTests
+namespace Energinet.DataHub.MeteringPoints.Tests.Domain.MeteringPoints
 {
-    public static class SampleData
+    [UnitTest]
+    public class MeteringPointTests
     {
-        public static string GsrnNumber => "571234567891234568";
+        [Fact]
+        public void ShouldRaiseEventWhenCreated()
+        {
+            var meteringPoint = new MeteringPoint(MeteringPointId.New(), GsrnNumber.Create(SampleData.GsrnNumber), MeteringPointType.Consumption);
 
-        public static string TypeOfMeteringPoint => "Consumption";
-
-        public static string Transaction => Guid.NewGuid().ToString();
+            var createdEvent = meteringPoint.DomainEvents.FirstOrDefault(e => e is MeteringPointCreated);
+            Assert.NotNull(createdEvent);
+        }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/SampleData.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/SampleData.cs
@@ -14,14 +14,10 @@
 
 using System;
 
-namespace Energinet.DataHub.MeteringPoints.IntegrationTests
+namespace Energinet.DataHub.MeteringPoints.Tests
 {
     public static class SampleData
     {
         public static string GsrnNumber => "571234567891234568";
-
-        public static string TypeOfMeteringPoint => "Consumption";
-
-        public static string Transaction => Guid.NewGuid().ToString();
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

This PR enriches the `MeteringPoint` model with the following:

- `MeteringPointId`
- `GsrnNumber`
- `PhysicalStatus`
- `MeteringPointType`
- `MeteringPointCreated` domain event

Primitives for the remaining properties have also been added order to enable EF core integration, but these will soon be replaced with proper value objects.
