### PR TITLE
Add address

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
@@ -39,10 +39,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
             var meteringPoint = new ConsumptionMeteringPoint(
                 MeteringPointId.New(),
                 GsrnNumber.Create(request.GsrnNumber),
-                request.InstallationLocationAddress.StreetName,
-                request.InstallationLocationAddress.PostCode,
-                request.InstallationLocationAddress.CityName,
-                request.InstallationLocationAddress.CountryCode,
+                CreateAddress(request),
                 request.InstallationLocationAddress.IsWashable,
                 PhysicalState.New,
                 EnumerationType.FromName<MeteringPointSubType>(request.SubTypeOfMeteringPoint),
@@ -66,6 +63,15 @@ namespace Energinet.DataHub.MeteringPoints.Application
             _meteringPointRepository.Add(meteringPoint);
 
             return Task.FromResult(BusinessProcessResult.Ok(request.TransactionId));
+        }
+
+        private Domain.MeteringPoints.Address CreateAddress(CreateMeteringPoint request)
+        {
+            return Domain.MeteringPoints.Address.Create(
+                request.InstallationLocationAddress.StreetName,
+                request.InstallationLocationAddress.PostCode,
+                request.InstallationLocationAddress.CityName,
+                request.InstallationLocationAddress.CountryCode);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
@@ -38,8 +38,4 @@ limitations under the License.
     <PackageReference Include="NodaTime" Version="3.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Remove="MeteringPoints\Address.cs" />
-  </ItemGroup>
-
 </Project>

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/Address.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/Address.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
+{
+    public class Address : ValueObject
+    {
+        private Address(string streetName, string postCode, string cityName, string countryCode)
+        {
+            StreetName = streetName;
+            PostCode = postCode;
+            CityName = cityName;
+            CountryCode = countryCode;
+        }
+
+        public string StreetName { get; }
+
+        public string PostCode { get; }
+
+        public string CityName { get; }
+
+        public string CountryCode { get; }
+
+        public static Address Create(string streetName, string postCode, string cityName, string countryCode)
+        {
+            return new Address(streetName, postCode, cityName, countryCode);
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
@@ -19,13 +19,10 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public class ConsumptionMeteringPoint : MeteringPoint
     {
-        public ConsumptionMeteringPoint(
+       public ConsumptionMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
-            string streetName,
-            string postCode,
-            string cityName,
-            string countryCode,
+            Address address,
             bool isAddressWashable,
             PhysicalState physicalState,
             MeteringPointSubType meteringPointSubType,
@@ -48,10 +45,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             : base(
                 id,
                 gsrnNumber,
-                streetName,
-                postCode,
-                cityName,
-                countryCode,
+                address,
                 isAddressWashable,
                 physicalState,
                 meteringPointSubType,
@@ -75,14 +69,20 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             ProductType = ProductType.EnergyActive;
         }
 
-        public SettlementMethod SettlementMethod { get; }
+       #pragma warning disable CS8618 // Disable non-nullable check
+       private ConsumptionMeteringPoint()
+       {
+           //EF core only
+       }
 
-        public string NetSettlementGroup { get; }
+       public SettlementMethod SettlementMethod { get; }
 
-        public DisconnectionType DisconnectionType { get; }
+       public string NetSettlementGroup { get; }
 
-        public ConnectionType ConnectionType { get; }
+       public DisconnectionType DisconnectionType { get; }
 
-        public AssetType AssetType { get; }
+       public ConnectionType ConnectionType { get; }
+
+       public AssetType AssetType { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
@@ -69,11 +69,53 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             ProductType = ProductType.EnergyActive;
         }
 
-       #pragma warning disable CS8618 // Disable non-nullable check
-       private ConsumptionMeteringPoint()
-       {
-           //EF core only
-       }
+       private ConsumptionMeteringPoint(
+                  MeteringPointId id,
+                  GsrnNumber gsrnNumber,
+                  bool isAddressWashable,
+                  PhysicalState physicalState,
+                  MeteringPointSubType meteringPointSubType,
+                  MeteringPointType meteringPointType,
+                  GridAreaId gridAreaId,
+                  GsrnNumber powerPlant,
+                  string locationDescription,
+                  string parentRelatedMeteringPoint,
+                  MeasurementUnitType unitType,
+                  string meterNumber,
+                  ReadingOccurrence meterReadingOccurrence,
+                  int maximumCurrent,
+                  int maximumPower,
+                  Instant? occurenceDate,
+                  SettlementMethod settlementMethod,
+                  string netSettlementGroup,
+                  DisconnectionType disconnectionType,
+                  ConnectionType connectionType,
+                  AssetType assetType)
+                  : base(
+                      id,
+                      gsrnNumber,
+                      isAddressWashable,
+                      physicalState,
+                      meteringPointSubType,
+                      meteringPointType,
+                      gridAreaId,
+                      powerPlant,
+                      locationDescription,
+                      parentRelatedMeteringPoint,
+                      unitType,
+                      meterNumber,
+                      meterReadingOccurrence,
+                      maximumCurrent,
+                      maximumPower,
+                      occurenceDate)
+              {
+                  SettlementMethod = settlementMethod;
+                  NetSettlementGroup = netSettlementGroup;
+                  DisconnectionType = disconnectionType;
+                  ConnectionType = connectionType;
+                  AssetType = assetType;
+                  ProductType = ProductType.EnergyActive;
+              }
 
        public SettlementMethod SettlementMethod { get; }
 

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
@@ -22,10 +22,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         public ExchangeMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
-            string streetName,
-            string postCode,
-            string cityName,
-            string countryCode,
+            Address address,
             bool isAddressWashable,
             PhysicalState physicalState,
             MeteringPointSubType meteringPointSubType,
@@ -45,10 +42,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             : base(
                 id,
                 gsrnNumber,
-                streetName,
-                postCode,
-                cityName,
-                countryCode,
+                address,
                 isAddressWashable,
                 physicalState,
                 meteringPointSubType,
@@ -67,6 +61,12 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             ToGrid = toGrid;
             FromGrid = fromGrid;
             ProductType = ProductType.EnergyReactive;
+        }
+
+        #pragma warning disable CS8618 // Disable non-nullable check
+        private ExchangeMeteringPoint()
+        {
+            // EF core only
         }
 
         public string FromGrid { get; }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
@@ -63,10 +63,46 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             ProductType = ProductType.EnergyReactive;
         }
 
-        #pragma warning disable CS8618 // Disable non-nullable check
-        private ExchangeMeteringPoint()
+        private ExchangeMeteringPoint(
+            MeteringPointId id,
+            GsrnNumber gsrnNumber,
+            bool isAddressWashable,
+            PhysicalState physicalState,
+            MeteringPointSubType meteringPointSubType,
+            MeteringPointType meteringPointType,
+            GridAreaId gridAreaId,
+            GsrnNumber powerPlant,
+            string locationDescription,
+            string parentRelatedMeteringPoint,
+            MeasurementUnitType unitType,
+            string meterNumber,
+            ReadingOccurrence meterReadingOccurrence,
+            int maximumCurrent,
+            int maximumPower,
+            Instant? occurenceDate,
+            string toGrid,
+            string fromGrid)
+            : base(
+                id,
+                gsrnNumber,
+                isAddressWashable,
+                physicalState,
+                meteringPointSubType,
+                meteringPointType,
+                gridAreaId,
+                powerPlant,
+                locationDescription,
+                parentRelatedMeteringPoint,
+                unitType,
+                meterNumber,
+                meterReadingOccurrence,
+                maximumCurrent,
+                maximumPower,
+                occurenceDate)
         {
-            // EF core only
+            ToGrid = toGrid;
+            FromGrid = fromGrid;
+            ProductType = ProductType.EnergyReactive;
         }
 
         public string FromGrid { get; }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
@@ -22,13 +22,15 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
     {
         //Disable nullable check
         #pragma warning disable CS8618
+        protected MeteringPoint()
+        {
+            //For EF core only
+        }
+
         protected MeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
-            string streetName,
-            string postCode,
-            string cityName,
-            string countryCode,
+            Address address,
             bool isAddressWashable,
             PhysicalState physicalState,
             MeteringPointSubType meteringPointSubType,
@@ -46,10 +48,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         {
             Id = id;
             GsrnNumber = gsrnNumber;
-            StreetName = streetName;
-            PostCode = postCode;
-            CityName = cityName;
-            CountryCode = countryCode;
+            Address = address;
             IsAddressWashable = isAddressWashable;
             PhysicalState = physicalState;
             MeteringPointSubType = meteringPointSubType;
@@ -80,14 +79,6 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 
         public MeteringPointId Id { get; }
 
-        public string StreetName { get; }
-
-        public string PostCode { get; }
-
-        public string CityName { get; }
-
-        public string CountryCode { get; }
-
         public bool IsAddressWashable { get; }
 
         public ReadingOccurrence MeterReadingOccurrence { get; }
@@ -109,5 +100,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         public Instant? OccurenceDate { get; }
 
         public string MeterNumber { get; }
+
+        public Address Address { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
@@ -20,11 +20,41 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public abstract class MeteringPoint : AggregateRootBase
     {
-        //Disable nullable check
-        #pragma warning disable CS8618
-        protected MeteringPoint()
+        #pragma warning disable CS8618 // Disable non-nullable check
+        protected MeteringPoint(
+            MeteringPointId id,
+            GsrnNumber gsrnNumber,
+            bool isAddressWashable,
+            PhysicalState physicalState,
+            MeteringPointSubType meteringPointSubType,
+            MeteringPointType meteringPointType,
+            GridAreaId gridAreaId,
+            GsrnNumber powerPlant,
+            string locationDescription,
+            string parentRelatedMeteringPoint,
+            MeasurementUnitType unitType,
+            string meterNumber,
+            ReadingOccurrence meterReadingOccurrence,
+            int maximumCurrent,
+            int maximumPower,
+            Instant? occurenceDate)
         {
-            //For EF core only
+            Id = id;
+            GsrnNumber = gsrnNumber;
+            IsAddressWashable = isAddressWashable;
+            PhysicalState = physicalState;
+            MeteringPointSubType = meteringPointSubType;
+            MeteringPointType = meteringPointType;
+            GridAreaId = gridAreaId;
+            PowerPlant = powerPlant;
+            LocationDescription = locationDescription;
+            ParentRelatedMeteringPoint = parentRelatedMeteringPoint;
+            UnitType = unitType;
+            MeterNumber = meterNumber;
+            MeterReadingOccurrence = meterReadingOccurrence;
+            MaximumCurrent = maximumCurrent;
+            MaximumPower = maximumPower;
+            OccurenceDate = occurenceDate;
         }
 
         protected MeteringPoint(

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
@@ -22,10 +22,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         public ProductionMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
-            string streetName,
-            string postCode,
-            string cityName,
-            string countryCode,
+            Address address,
             bool isAddressWashable,
             PhysicalState physicalState,
             MeteringPointSubType meteringPointSubType,
@@ -47,10 +44,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             : base(
                 id,
                 gsrnNumber,
-                streetName,
-                postCode,
-                cityName,
-                countryCode,
+                address,
                 isAddressWashable,
                 physicalState,
                 meteringPointSubType,
@@ -71,6 +65,12 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             DisconnectionType = disconnectionType;
             ConnectionType = connectionType;
             ProductType = ProductType.EnergyActive;
+        }
+
+        #pragma warning disable CS8618 // Disable non-nullable check
+        private ProductionMeteringPoint()
+        {
+            //EF core only
         }
 
         public int ProductionObligation { get; }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
@@ -67,10 +67,50 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             ProductType = ProductType.EnergyActive;
         }
 
-        #pragma warning disable CS8618 // Disable non-nullable check
-        private ProductionMeteringPoint()
+        public ProductionMeteringPoint(
+            MeteringPointId id,
+            GsrnNumber gsrnNumber,
+            bool isAddressWashable,
+            PhysicalState physicalState,
+            MeteringPointSubType meteringPointSubType,
+            MeteringPointType meteringPointType,
+            GridAreaId gridAreaId,
+            GsrnNumber powerPlant,
+            string locationDescription,
+            string parentRelatedMeteringPoint,
+            MeasurementUnitType unitType,
+            string meterNumber,
+            ReadingOccurrence meterReadingOccurrence,
+            int maximumCurrent,
+            int maximumPower,
+            Instant? occurenceDate,
+            int productionObligation,
+            int netSettlementGroup,
+            DisconnectionType disconnectionType,
+            ConnectionType connectionType)
+            : base(
+                id,
+                gsrnNumber,
+                isAddressWashable,
+                physicalState,
+                meteringPointSubType,
+                meteringPointType,
+                gridAreaId,
+                powerPlant,
+                locationDescription,
+                parentRelatedMeteringPoint,
+                unitType,
+                meterNumber,
+                meterReadingOccurrence,
+                maximumCurrent,
+                maximumPower,
+                occurenceDate)
         {
-            //EF core only
+            ProductionObligation = productionObligation;
+            NetSettlementGroup = netSettlementGroup;
+            DisconnectionType = disconnectionType;
+            ConnectionType = connectionType;
+            ProductType = ProductType.EnergyActive;
         }
 
         public int ProductionObligation { get; }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
@@ -44,10 +44,17 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoi
                     toDbValue => toDbValue.Value,
                     fromDbValue => GsrnNumber.Create(fromDbValue));
 
-            builder.Property(x => x.StreetName);
-            builder.Property(x => x.PostCode);
-            builder.Property(x => x.CityName);
-            builder.Property(x => x.CountryCode);
+            builder.OwnsOne(x => x.Address, y =>
+            {
+                y.Property(x => x.StreetName).HasColumnName("StreetName");
+                y.Property(x => x.CityName).HasColumnName("CityName");
+                y.Property(x => x.CountryCode).HasColumnName("CountryCode");
+                y.Property(x => x.PostCode).HasColumnName("PostCode");
+            });
+            // builder.Property(x => x.Address.StreetName);
+            // builder.Property(x => x.Address.PostCode);
+            // builder.Property(x => x.Address.CityName);
+            // builder.Property(x => x.Address.CountryCode);
             builder.Property(x => x.IsAddressWashable);
 
             builder.Property(x => x.PhysicalState)

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/MeteringPointTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/MeteringPointTests.cs
@@ -31,10 +31,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Domain.MeteringPoints
             var meteringPoint = new ConsumptionMeteringPoint(
                 MeteringPointId.New(),
                 GsrnNumber.Create(SampleData.GsrnNumber),
-                SampleData.StreetName,
-                SampleData.PostCode,
-                SampleData.CityName,
-                SampleData.CountryCode,
+                Address.Create(SampleData.StreetName, SampleData.PostCode, SampleData.CityName, SampleData.CountryCode),
                 SampleData.IsAddressWashable,
                 EnumerationType.FromName<PhysicalState>(SampleData.PhysicalStateName),
                 EnumerationType.FromName<MeteringPointSubType>(SampleData.SubTypeName),


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Adds `Address` value object to `MeteringPoint`.

In order to get EF core working, it has been necessary to add private parameterless ctors to metering point objects. However, since EF core is capable of using contructors with parameteres, we should research on this to see if we can get rid of these constructors.
