### PR TITLE
Change public properties to private fields to encapsulate internals

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
@@ -19,6 +19,12 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public class ConsumptionMeteringPoint : MeteringPoint
     {
+        private SettlementMethod _settlementMethod;
+        private string _netSettlementGroup;
+        private DisconnectionType _disconnectionType;
+        private ConnectionType _connectionType;
+        private AssetType _assetType;
+
         public ConsumptionMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
@@ -67,22 +73,12 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 maximumPower,
                 occurenceDate)
         {
-            SettlementMethod = settlementMethod;
-            NetSettlementGroup = netSettlementGroup;
-            DisconnectionType = disconnectionType;
-            ConnectionType = connectionType;
-            AssetType = assetType;
+            _settlementMethod = settlementMethod;
+            _netSettlementGroup = netSettlementGroup;
+            _disconnectionType = disconnectionType;
+            _connectionType = connectionType;
+            _assetType = assetType;
             ProductType = ProductType.EnergyActive;
         }
-
-        public SettlementMethod SettlementMethod { get; }
-
-        public string NetSettlementGroup { get; }
-
-        public DisconnectionType DisconnectionType { get; }
-
-        public ConnectionType ConnectionType { get; }
-
-        public AssetType AssetType { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
@@ -37,7 +37,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             MeteringPointSubType meteringPointSubType,
             MeteringPointType meteringPointType,
             GridAreaId gridAreaId,
-            GsrnNumber powerPlant,
+            GsrnNumber powerPlantGsrnNumber,
             string locationDescription,
             string parentRelatedMeteringPoint,
             MeasurementUnitType unitType,
@@ -63,7 +63,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 meteringPointSubType,
                 meteringPointType,
                 gridAreaId,
-                powerPlant,
+                powerPlantGsrnNumber,
                 locationDescription,
                 parentRelatedMeteringPoint,
                 unitType,
@@ -78,7 +78,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             _disconnectionType = disconnectionType;
             _connectionType = connectionType;
             _assetType = assetType;
-            ProductType = ProductType.EnergyActive;
+            _productType = ProductType.EnergyActive;
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
@@ -34,7 +34,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             MeteringPointSubType meteringPointSubType,
             MeteringPointType meteringPointType,
             GridAreaId gridAreaId,
-            GsrnNumber powerPlant,
+            GsrnNumber powerPlantGsrnNumber,
             string locationDescription,
             string parentRelatedMeteringPoint,
             MeasurementUnitType unitType,
@@ -57,7 +57,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 meteringPointSubType,
                 meteringPointType,
                 gridAreaId,
-                powerPlant,
+                powerPlantGsrnNumber,
                 locationDescription,
                 parentRelatedMeteringPoint,
                 unitType,
@@ -69,7 +69,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         {
             _toGrid = toGrid;
             _fromGrid = fromGrid;
-            ProductType = ProductType.EnergyReactive;
+            _productType = ProductType.EnergyReactive;
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ExchangeMeteringPoint.cs
@@ -19,6 +19,9 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public class ExchangeMeteringPoint : MeteringPoint
     {
+        private string _fromGrid;
+        private string _toGrid;
+
         public ExchangeMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
@@ -64,13 +67,9 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 maximumPower,
                 occurenceDate)
         {
-            ToGrid = toGrid;
-            FromGrid = fromGrid;
+            _toGrid = toGrid;
+            _fromGrid = fromGrid;
             ProductType = ProductType.EnergyReactive;
         }
-
-        public string FromGrid { get; }
-
-        public string ToGrid { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
@@ -20,8 +20,25 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public abstract class MeteringPoint : AggregateRootBase
     {
-        //Disable nullable check
-        #pragma warning disable CS8618
+        #pragma warning disable SA1401 // Field cannot be private since it is set by derivatives
+        protected ProductType _productType;
+        #pragma warning restore
+        private GridAreaId _gridAreaId;
+        private MeteringPointType _meteringPointType;
+        private MeteringPointSubType _meteringPointSubType;
+        private PhysicalState _physicalState;
+        private bool _isAddressWashable;
+        private ReadingOccurrence _meterReadingOccurrence;
+        private int _maximumCurrent;
+        private int _maximumPower;
+        private GsrnNumber _powerPlantGsrnNumber;
+        private string _locationDescription;
+        private string _parentRelatedMeteringPoint;
+        private MeasurementUnitType _unitType;
+        private Instant? _occurenceDate;
+        private string _meterNumber;
+
+        #pragma warning disable CS8618 //Disable nullable check
         protected MeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
@@ -34,7 +51,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             MeteringPointSubType meteringPointSubType,
             MeteringPointType meteringPointType,
             GridAreaId gridAreaId,
-            GsrnNumber powerPlant,
+            GsrnNumber powerPlantGsrnNumber,
             string locationDescription,
             string parentRelatedMeteringPoint,
             MeasurementUnitType unitType,
@@ -50,35 +67,27 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             PostCode = postCode;
             CityName = cityName;
             CountryCode = countryCode;
-            IsAddressWashable = isAddressWashable;
-            PhysicalState = physicalState;
-            MeteringPointSubType = meteringPointSubType;
-            MeteringPointType = meteringPointType;
-            GridAreaId = gridAreaId;
-            PowerPlant = powerPlant;
-            LocationDescription = locationDescription;
-            ParentRelatedMeteringPoint = parentRelatedMeteringPoint;
-            UnitType = unitType;
-            MeterNumber = meterNumber;
-            MeterReadingOccurrence = meterReadingOccurrence;
-            MaximumCurrent = maximumCurrent;
-            MaximumPower = maximumPower;
-            OccurenceDate = occurenceDate;
+            _isAddressWashable = isAddressWashable;
+            _physicalState = physicalState;
+            _meteringPointSubType = meteringPointSubType;
+            _meteringPointType = meteringPointType;
+            _gridAreaId = gridAreaId;
+            _powerPlantGsrnNumber = powerPlantGsrnNumber;
+            _locationDescription = locationDescription;
+            _parentRelatedMeteringPoint = parentRelatedMeteringPoint;
+            _unitType = unitType;
+            _meterNumber = meterNumber;
+            _meterReadingOccurrence = meterReadingOccurrence;
+            _maximumCurrent = maximumCurrent;
+            _maximumPower = maximumPower;
+            _occurenceDate = occurenceDate;
 
             AddDomainEvent(new MeteringPointCreated(id, GsrnNumber, meteringPointType, gridAreaId));
         }
 
-        public GridAreaId GridAreaId { get; }
-
-        public MeteringPointType MeteringPointType { get; }
-
-        public MeteringPointSubType MeteringPointSubType { get; }
-
-        public PhysicalState PhysicalState { get; }
+        public MeteringPointId Id { get; }
 
         public GsrnNumber GsrnNumber { get; }
-
-        public MeteringPointId Id { get; }
 
         public string StreetName { get; }
 
@@ -87,27 +96,5 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         public string CityName { get; }
 
         public string CountryCode { get; }
-
-        public bool IsAddressWashable { get; }
-
-        public ReadingOccurrence MeterReadingOccurrence { get; }
-
-        public int MaximumCurrent { get; }
-
-        public int MaximumPower { get; }
-
-        public GsrnNumber PowerPlant { get; }
-
-        public string LocationDescription { get; }
-
-        public ProductType ProductType { get; protected set; }
-
-        public string ParentRelatedMeteringPoint { get; }
-
-        public MeasurementUnitType UnitType { get; }
-
-        public Instant? OccurenceDate { get; }
-
-        public string MeterNumber { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
@@ -19,6 +19,11 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
 {
     public class ProductionMeteringPoint : MeteringPoint
     {
+        private int _productionObligation;
+        private int _netSettlementGroup;
+        private DisconnectionType _disconnectionType;
+        private ConnectionType _connectionType;
+
         public ProductionMeteringPoint(
             MeteringPointId id,
             GsrnNumber gsrnNumber,
@@ -66,19 +71,11 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 maximumPower,
                 occurenceDate)
         {
-            ProductionObligation = productionObligation;
-            NetSettlementGroup = netSettlementGroup;
-            DisconnectionType = disconnectionType;
-            ConnectionType = connectionType;
+            _productionObligation = productionObligation;
+            _netSettlementGroup = netSettlementGroup;
+            _disconnectionType = disconnectionType;
+            _connectionType = connectionType;
             ProductType = ProductType.EnergyActive;
         }
-
-        public int ProductionObligation { get; }
-
-        public int NetSettlementGroup { get; }
-
-        public DisconnectionType DisconnectionType { get; }
-
-        public ConnectionType ConnectionType { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ProductionMeteringPoint.cs
@@ -36,7 +36,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             MeteringPointSubType meteringPointSubType,
             MeteringPointType meteringPointType,
             GridAreaId gridAreaId,
-            GsrnNumber powerPlant,
+            GsrnNumber powerPlantGsrnNumber,
             string locationDescription,
             string parentRelatedMeteringPoint,
             MeasurementUnitType unitType,
@@ -61,7 +61,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
                 meteringPointSubType,
                 meteringPointType,
                 gridAreaId,
-                powerPlant,
+                powerPlantGsrnNumber,
                 locationDescription,
                 parentRelatedMeteringPoint,
                 unitType,
@@ -75,7 +75,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             _netSettlementGroup = netSettlementGroup;
             _disconnectionType = disconnectionType;
             _connectionType = connectionType;
-            ProductType = ProductType.EnergyActive;
+            _productType = ProductType.EnergyActive;
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
@@ -48,53 +48,73 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoi
             builder.Property(x => x.PostCode);
             builder.Property(x => x.CityName);
             builder.Property(x => x.CountryCode);
-            builder.Property(x => x.IsAddressWashable);
 
-            builder.Property(x => x.PhysicalState)
+            builder.Property<bool>("_isAddressWashable")
+                .HasColumnName("IsAddressWashable");
+
+            builder.Property<PhysicalState>("_physicalState")
                 .HasColumnName("PhysicalStatusOfMeteringPoint")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<PhysicalState>(fromDbValue));
 
-            builder.Property(x => x.MeteringPointSubType)
+            builder.Property<MeteringPointSubType>("_meteringPointSubType")
                 .HasColumnName("MeteringPointSubType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<MeteringPointSubType>(fromDbValue));
 
-            builder.Property(x => x.MeteringPointType)
+            builder.Property<MeteringPointType>("_meteringPointType")
                 .HasColumnName("TypeOfMeteringPoint")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<MeteringPointType>(fromDbValue));
 
-            builder.Property(x => x.GridAreaId)
+            builder.Property<GridAreaId>("_gridAreaId")
                 .HasColumnName("MeteringGridArea")
                 .HasConversion(
                     toDbValue => toDbValue.Value,
                     fromDbValue => new GridAreaId(fromDbValue));
 
-            builder.Property(x => x.PowerPlant)
+            builder.Property<GsrnNumber>("_powerPlantGsrnNumber")
+                .HasColumnName("PowerPlant")
                 .HasConversion(toDbValue => toDbValue.Value, fromDbValue => GsrnNumber.Create(fromDbValue));
-            builder.Property(x => x.LocationDescription);
-            builder.Property(x => x.ProductType)
+
+            builder.Property<string>("_locationDescription")
+                .HasColumnName("LocationDescription");
+
+            builder.Property<ProductType>("_productType")
+                .HasColumnName("ProductType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<ProductType>(fromDbValue));
-            builder.Property(x => x.ParentRelatedMeteringPoint);
-            builder.Property(x => x.UnitType)
+
+            builder.Property("_parentRelatedMeteringPoint")
+                .HasColumnName("ParentRelatedMeteringPoint");
+
+            builder.Property<MeasurementUnitType>("_unitType")
                 .HasColumnName("UnitType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<MeasurementUnitType>(fromDbValue));
-            builder.Property(x => x.MeterNumber);
-            builder.Property(x => x.MeterReadingOccurrence)
+
+            builder.Property("_meterNumber")
+                .HasColumnName("MeterNumber");
+
+            builder.Property<ReadingOccurrence>("_meterReadingOccurrence")
+                .HasColumnName("MeterReadingOccurrence")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<ReadingOccurrence>(fromDbValue));
-            builder.Property(x => x.MaximumCurrent);
-            builder.Property(x => x.MaximumPower);
-            builder.Property(x => x.OccurenceDate);
+
+            builder.Property("_maximumCurrent")
+                .HasColumnName("MaximumCurrent");
+
+            builder.Property("_maximumPower")
+                .HasColumnName("MaximumPower");
+
+            builder.Property("_occurenceDate")
+                .HasColumnName("OccurenceDate");
         }
     }
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
@@ -169,8 +169,10 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoi
 
             builder.ToTable("ExchangeMeteringPoints", "dbo");
 
-            builder.Property(x => x.ToGrid);
-            builder.Property(x => x.FromGrid);
+            builder.Property("_toGrid")
+                .HasColumnName("ToGrid");
+            builder.Property("_fromGrid")
+                .HasColumnName("FromGrid");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
@@ -141,13 +141,17 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoi
 
             builder.ToTable("ProductionMeteringPoints", "dbo");
 
-            builder.Property(x => x.ProductionObligation);
-            builder.Property(x => x.NetSettlementGroup);
-            builder.Property(x => x.DisconnectionType)
+            builder.Property("_productionObligation")
+                .HasColumnName("ProductionObligation");
+            builder.Property("_netSettlementGroup")
+                .HasColumnName("NetSettlementGroup");
+            builder.Property<DisconnectionType>("_disconnectionType")
+                .HasColumnName("DisconnectionType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<DisconnectionType>(fromDbValue));
-            builder.Property(x => x.ConnectionType)
+            builder.Property<ConnectionType>("_connectionType")
+                .HasColumnName("ConnectionType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<ConnectionType>(fromDbValue));

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/MeteringPoints/MeteringPointEntityConfiguration.cs
@@ -109,24 +109,31 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoi
 
             builder.ToTable("ConsumptionMeteringPoints", "dbo");
 
-            builder.Property(x => x.AssetType)
+            builder.Property<AssetType>("_assetType")
+                .HasColumnName("AssetType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<AssetType>(fromDbValue));
-            builder.Property(x => x.ConnectionType);
-            builder.Property(x => x.DisconnectionType)
-                .HasConversion(
-                    toDbValue => toDbValue.Name,
-                    fromDbValue => EnumerationType.FromName<DisconnectionType>(fromDbValue));
-            builder.Property(x => x.ConnectionType)
+            builder.Property<ConnectionType>("_connectionType")
+                .HasColumnName("ConnectionType")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<ConnectionType>(fromDbValue));
-            builder.Property(x => x.SettlementMethod)
+
+            builder.Property<DisconnectionType>("_disconnectionType")
+                .HasColumnName("DisconnectionType")
+                .HasConversion(
+                    toDbValue => toDbValue.Name,
+                    fromDbValue => EnumerationType.FromName<DisconnectionType>(fromDbValue));
+
+            builder.Property<SettlementMethod>("_settlementMethod")
+                .HasColumnName("SettlementMethod")
                 .HasConversion(
                     toDbValue => toDbValue.Name,
                     fromDbValue => EnumerationType.FromName<SettlementMethod>(fromDbValue));
-            builder.Property(x => x.NetSettlementGroup);
+
+            builder.Property("_netSettlementGroup")
+                .HasColumnName("NetSettlementGroup");
         }
     }
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
This PR changes `MeteringPoint` public properties to private fields.
The domain model is write-model, and thus, only the model itself need to know about the internals.
