### PR TITLE
Make status appear as second property in reject message to conform to standard layout

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/CreateMeteringPoint/CreateMeteringPointRejected.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/CreateMeteringPoint/CreateMeteringPointRejected.cs
@@ -18,8 +18,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.CreateMeteringPoin
 {
     public record CreateMeteringPointRejected(
         string TransactionId,
-        string GsrnNumber,
         string Status, // TODO: Is status implicit in Rejected from type?
+        string GsrnNumber,
         string Reason,
         Error[] Errors);
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/GsrnNumberMustBeValidDomainErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/GsrnNumberMustBeValidDomainErrorConverter.cs
@@ -18,7 +18,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
     {
         protected override Error Convert(Domain.MeteringPoints.Rules.GsrnNumberMustBeValidRuleError error)
         {
-            return new("E10", $"A metering point cannot be registered in CCR without a valid identification");
+            return new("E10", $"A metering point cannot be registered in GEH without a valid identification");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/GsrnNumberMustBeValidErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/GsrnNumberMustBeValidErrorConverter.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
     {
         protected override Error Convert(GsrnNumberMustBeValidValidationError error)
         {
-            return new("E10", $"A metering point cannot be registered in CCR without a valid identification");
+            return new("E10", $"A metering point cannot be registered in GEH without a valid identification");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/ErrorValidationRegistrationTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/ErrorValidationRegistrationTests.cs
@@ -50,7 +50,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests
             var validationError = validationErrors.First();
             var errorMessage = sut.GetErrorMessage(validationError);
             errorMessage.Code.Should().Be("E10");
-            errorMessage.Description.Should().Be("A metering point cannot be registered in CCR without a valid identification");
+            errorMessage.Description.Should().Be("A metering point cannot be registered in GEH without a valid identification");
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
