### PR TITLE
Added input validations

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
@@ -22,6 +22,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
             string PostCode = "",
             string CityName = "",
             string CountryCode = "",
+            string StreetCode = "",
             bool IsWashable = false,
             string GsrnNumber = "",
             string TypeOfMeteringPoint = "",

--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
@@ -23,6 +23,8 @@ namespace Energinet.DataHub.MeteringPoints.Application
             string CityName = "",
             string CountryCode = "",
             string StreetCode = "",
+            string FloorIdentification = "",
+            string RoomIdentification = "",
             bool IsWashable = false,
             string GsrnNumber = "",
             string TypeOfMeteringPoint = "",

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
@@ -29,6 +29,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation
             RuleFor(request => request).SetValidator(new AddressMustBeValidRule());
             RuleFor(request => request).SetValidator(new MeteringPointSubTypeMustBeValidRule());
             RuleFor(request => request).SetValidator(new MeterNumberMustBeValidRule());
+            RuleFor(request => request).SetValidator(new NetSettlementGroupRule());
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AddressMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AddressMustBeValidRule.cs
@@ -40,6 +40,10 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 .SetValidator(request => new CityNameMaximumLengthMustBeValidRule(request.GsrnNumber));
             RuleFor(request => request.StreetCode)
                 .SetValidator(request => new StreetCodeMustBeValidRule(request.GsrnNumber));
+            RuleFor(request => request.FloorIdentification)
+                .SetValidator(request => new FloorIdentificationRule(request.GsrnNumber));
+            RuleFor(request => request.RoomIdentification)
+                .SetValidator(request => new RoomIdentificationRule(request.GsrnNumber));
         }
 
         private static bool MeteringPointTypeIsProductionOrConsumption(CreateMeteringPoint createMeteringPoint)

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AddressMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AddressMustBeValidRule.cs
@@ -38,6 +38,8 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 .SetValidator(request => new StreetNameMaximumLengthMustBeValidRule(request.GsrnNumber));
             RuleFor(request => request.CityName)
                 .SetValidator(request => new CityNameMaximumLengthMustBeValidRule(request.GsrnNumber));
+            RuleFor(request => request.StreetCode)
+                .SetValidator(request => new StreetCodeMustBeValidRule(request.GsrnNumber));
         }
 
         private static bool MeteringPointTypeIsProductionOrConsumption(CreateMeteringPoint createMeteringPoint)

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/FloorIdentificationRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/FloorIdentificationRule.cs
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using FluentValidation;
 
-namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
 {
-    public class StreetCodeErrorConverter : ErrorConverter<StreetCodeValidationError>
+    public class FloorIdentificationRule : AbstractValidator<string>
     {
-        protected override ErrorMessage Convert(StreetCodeValidationError validationError)
-        {
-            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+        private const int FloorIdentificationLength = 4;
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+        public FloorIdentificationRule(string gsrnNumber)
+        {
+            CascadeMode = CascadeMode.Stop;
+
+            RuleFor(floorIdentification => floorIdentification)
+                .MaximumLength(FloorIdentificationLength)
+                .WithState(floorIdentification => new FloorIdentificationValidationError(gsrnNumber, floorIdentification));
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/NetSettlementGroupRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/NetSettlementGroupRule.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+using FluentValidation;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
+{
+    public class NetSettlementGroupRule : AbstractValidator<CreateMeteringPoint>
+    {
+        public NetSettlementGroupRule()
+        {
+            When(MeteringPointTypeIsProductionOrConsumption, () =>
+            {
+                RuleFor(request => request.NetSettlementGroup)
+                    .NotEmpty()
+                    .WithState(createMeteringPoint => new NetSettlementGroupMandatoryValidationError(createMeteringPoint.TypeOfMeteringPoint));
+
+                RuleFor(request => request.NetSettlementGroup)
+                    .Must(netSettlementGroup => AllowedNetSettlementGroupValues().Contains(netSettlementGroup.ToUpperInvariant()))
+                    .WithState(createMeteringPoint => new NetSettlementGroupInvalidValueValidationError(AllowedNetSettlementGroupValues(), createMeteringPoint.TypeOfMeteringPoint));
+            }).Otherwise(() =>
+            {
+                RuleFor(request => request.NetSettlementGroup)
+                    .Empty()
+                    .WithState(createMeteringPoint => new NetSettlementGroupNotAllowedValidationError(createMeteringPoint.TypeOfMeteringPoint));
+            });
+        }
+
+        private static bool MeteringPointTypeIsProductionOrConsumption(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(MeteringPointType.Consumption.Name, StringComparison.Ordinal)
+                   || createMeteringPoint.TypeOfMeteringPoint.Equals(MeteringPointType.Production.Name, StringComparison.Ordinal);
+        }
+
+        private static HashSet<string> AllowedNetSettlementGroupValues()
+        {
+            return EnumerationType.GetAll<NetSettlementGroup>().Select(x => x.Name.ToUpperInvariant()).ToHashSet();
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/NetSettlementGroupRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/NetSettlementGroupRule.cs
@@ -34,12 +34,12 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
 
                 RuleFor(request => request.NetSettlementGroup)
                     .Must(netSettlementGroup => AllowedNetSettlementGroupValues().Contains(netSettlementGroup.ToUpperInvariant()))
-                    .WithState(createMeteringPoint => new NetSettlementGroupInvalidValueValidationError(AllowedNetSettlementGroupValues(), createMeteringPoint.TypeOfMeteringPoint));
+                    .WithState(createMeteringPoint => new NetSettlementGroupInvalidValueValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.TypeOfMeteringPoint));
             }).Otherwise(() =>
             {
                 RuleFor(request => request.NetSettlementGroup)
                     .Empty()
-                    .WithState(createMeteringPoint => new NetSettlementGroupNotAllowedValidationError(createMeteringPoint.TypeOfMeteringPoint));
+                    .WithState(createMeteringPoint => new NetSettlementGroupNotAllowedValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.TypeOfMeteringPoint));
             });
         }
 

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/RoomIdentificationRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/RoomIdentificationRule.cs
@@ -12,19 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using FluentValidation;
 
-namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
 {
-    public class StreetCodeErrorConverter : ErrorConverter<StreetCodeValidationError>
+    public class RoomIdentificationRule : AbstractValidator<string>
     {
-        protected override ErrorMessage Convert(StreetCodeValidationError validationError)
-        {
-            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+        private const int RoomIdentificationLength = 4;
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+        public RoomIdentificationRule(string gsrnNumber)
+        {
+            CascadeMode = CascadeMode.Stop;
+
+            RuleFor(roomIdentification => roomIdentification)
+                .MaximumLength(RoomIdentificationLength)
+                .WithState(roomIdentification => new RoomIdentificationValidationError(gsrnNumber, roomIdentification));
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/StreetCodeMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/StreetCodeMustBeValidRule.cs
@@ -1,0 +1,35 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using FluentValidation;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
+{
+    public class StreetCodeMustBeValidRule : AbstractValidator<string>
+    {
+        private const int StreetCodeLength = 4;
+
+        public StreetCodeMustBeValidRule(string gsrnNumber)
+        {
+            CascadeMode = CascadeMode.Stop;
+
+            RuleFor(streetCode => streetCode)
+                .Length(StreetCodeLength)
+                .WithState(streetCode => new StreetCodeValidationError(gsrnNumber, streetCode))
+                .InclusiveBetween("0001", "9999")
+                .WithState(streetCode => new StreetCodeValidationError(gsrnNumber, streetCode));
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/FloorIdentificationValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/FloorIdentificationValidationError.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class FloorIdentificationValidationError : ValidationError
+    {
+        public FloorIdentificationValidationError(string gsrnNumber, string floorIdentification)
+        {
+            GsrnNumber = gsrnNumber;
+            FloorIdentification = floorIdentification;
+        }
+
+        public string GsrnNumber { get; }
+
+        public string FloorIdentification { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupInvalidValueValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupInvalidValueValidationError.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class NetSettlementGroupInvalidValueValidationError : ValidationError
+    {
+        public NetSettlementGroupInvalidValueValidationError(IEnumerable<string> allowedValues, string netNetSettlementGroup)
+        {
+            AllowedValues = allowedValues;
+            NetSettlementGroup = netNetSettlementGroup;
+        }
+
+        public IEnumerable<string> AllowedValues { get; }
+
+        public string NetSettlementGroup { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupInvalidValueValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupInvalidValueValidationError.cs
@@ -12,21 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
 {
     public class NetSettlementGroupInvalidValueValidationError : ValidationError
     {
-        public NetSettlementGroupInvalidValueValidationError(IEnumerable<string> allowedValues, string netNetSettlementGroup)
+        public NetSettlementGroupInvalidValueValidationError(string netNetSettlementGroup, string gsrnNumber)
         {
-            AllowedValues = allowedValues;
             NetSettlementGroup = netNetSettlementGroup;
+            GsrnNumber = gsrnNumber;
         }
 
-        public IEnumerable<string> AllowedValues { get; }
-
         public string NetSettlementGroup { get; }
+
+        public string GsrnNumber { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupMandatoryValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupMandatoryValidationError.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class NetSettlementGroupMandatoryValidationError : ValidationError
+    {
+        public NetSettlementGroupMandatoryValidationError(string meteringPointType)
+        {
+            MeteringPointType = meteringPointType;
+        }
+
+        public string MeteringPointType { get; set; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupNotAllowedValidationError.cs
@@ -18,11 +18,14 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErro
 {
     public class NetSettlementGroupNotAllowedValidationError : ValidationError
     {
-        public NetSettlementGroupNotAllowedValidationError(string meteringPointType)
+        public NetSettlementGroupNotAllowedValidationError(string meteringPointType, string netSettlementGroup)
         {
             MeteringPointType = meteringPointType;
+            NetSettlementGroup = netSettlementGroup;
         }
 
         public string MeteringPointType { get; }
+
+        public string NetSettlementGroup { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/NetSettlementGroupNotAllowedValidationError.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class NetSettlementGroupNotAllowedValidationError : ValidationError
+    {
+        public NetSettlementGroupNotAllowedValidationError(string meteringPointType)
+        {
+            MeteringPointType = meteringPointType;
+        }
+
+        public string MeteringPointType { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/RoomIdentificationValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/RoomIdentificationValidationError.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class RoomIdentificationValidationError : ValidationError
+    {
+        public RoomIdentificationValidationError(string gsrnNumber, string roomIdentification)
+        {
+            GsrnNumber = gsrnNumber;
+            RoomIdentification = roomIdentification;
+        }
+
+        public string GsrnNumber { get; }
+
+        public string RoomIdentification { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/StreetCodeValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/StreetCodeValidationError.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class StreetCodeValidationError : ValidationError
+    {
+        public StreetCodeValidationError(string gsrnNumber, string streetCode)
+        {
+            GsrnNumber = gsrnNumber;
+            StreetCode = streetCode;
+        }
+
+        public string GsrnNumber { get; }
+
+        public string StreetCode { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/FloorIdentificationErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/FloorIdentificationErrorConverter.cs
@@ -17,14 +17,14 @@ using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
 {
-    public class StreetCodeErrorConverter : ErrorConverter<StreetCodeValidationError>
+    public class FloorIdentificationErrorConverter : ErrorConverter<FloorIdentificationValidationError>
     {
-        protected override ErrorMessage Convert(StreetCodeValidationError validationError)
+        protected override ErrorMessage Convert(FloorIdentificationValidationError validationError)
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
             // TODO - which is the right code for this?
-            return new("CODE", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+            return new("CODE", $"Floor Identification {validationError.FloorIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds maximum of 4");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/FloorIdentificationErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/FloorIdentificationErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Floor Identification {validationError.FloorIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds maximum of 4");
+            return new ErrorMessage("E86", $"Floor identification {validationError.FloorIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds 4");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupInvalidValueErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupInvalidValueErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"The value {validationError.NetSettlementGroup} for Net settlement group is not valid. Allowed values are: {string.Join(',', validationError.AllowedValues)}");
+            return new ErrorMessage("D02", $"Net settlement group {validationError.NetSettlementGroup} for metering point {validationError.GsrnNumber} has wrong value (outside domain)");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupInvalidValueErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupInvalidValueErrorConverter.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class NetSettlementGroupInvalidValueErrorConverter : ErrorConverter<NetSettlementGroupInvalidValueValidationError>
+    {
+        protected override ErrorMessage Convert(NetSettlementGroupInvalidValueValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            // TODO - which is the right code for this?
+            return new("CODE", $"The value {validationError.NetSettlementGroup} for Net settlement group is not valid. Allowed values are: {string.Join(',', validationError.AllowedValues)}");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupMandatoryErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupMandatoryErrorConverter.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class NetSettlementGroupMandatoryErrorConverter : ErrorConverter<NetSettlementGroupMandatoryValidationError>
+    {
+        protected override ErrorMessage Convert(NetSettlementGroupMandatoryValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            // TODO - which is the right code for this?
+            return new("CODE", $"Net settlement group is mandatory for metering point type {validationError.MeteringPointType}");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupMandatoryErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupMandatoryErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Net settlement group is mandatory for metering point type {validationError.MeteringPointType}");
+            return new("D02", $"Net settlement group for metering point {validationError.MeteringPointType} is missing (type E17/E18)");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupNotAllowedErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Net settlement group is not allowed for metering point type {validationError.MeteringPointType}");
+            return new("D02", $"Net settlement group {validationError.NetSettlementGroup} is not allowed for metering point type {validationError.MeteringPointType}");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/NetSettlementGroupNotAllowedErrorConverter.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class NetSettlementGroupNotAllowedErrorConverter : ErrorConverter<NetSettlementGroupNotAllowedValidationError>
+    {
+        protected override ErrorMessage Convert(NetSettlementGroupNotAllowedValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            // TODO - which is the right code for this?
+            return new("CODE", $"Net settlement group is not allowed for metering point type {validationError.MeteringPointType}");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/RoomIdentificationErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/RoomIdentificationErrorConverter.cs
@@ -17,14 +17,14 @@ using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
 {
-    public class StreetCodeErrorConverter : ErrorConverter<StreetCodeValidationError>
+    public class RoomIdentificationErrorConverter : ErrorConverter<RoomIdentificationValidationError>
     {
-        protected override ErrorMessage Convert(StreetCodeValidationError validationError)
+        protected override ErrorMessage Convert(RoomIdentificationValidationError validationError)
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
             // TODO - which is the right code for this?
-            return new("CODE", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+            return new("CODE", $"Floor Identification {validationError.RoomIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds maximum of 4");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/RoomIdentificationErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/RoomIdentificationErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Floor Identification {validationError.RoomIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds maximum of 4");
+            return new ErrorMessage("E86", $"Room identification {validationError.RoomIdentification} for metering point {validationError.GsrnNumber} has a length that exceeds 4");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/StreetCodeErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/StreetCodeErrorConverter.cs
@@ -23,8 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
 
-            // TODO - which is the right code for this?
-            return new("CODE", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+            return new ErrorMessage("E86", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} is out of range or contains a non-digit character or has a length that does not equal 4");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/StreetCodeErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/StreetCodeErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class StreetCodeErrorConverter : ErrorConverter<StreetCodeValidationError>
+    {
+        protected override ErrorMessage Convert(StreetCodeValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new("E86", $"Street code {validationError.StreetCode} for metering point {validationError.GsrnNumber} has a length that is not within range 0001 to 9999");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
@@ -43,6 +43,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 .AddProperty(x => x.StreetName, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "streetDetail", "name")
                 .AddProperty(x => x.CityName, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "townDetail", "name")
                 .AddProperty(x => x.PostCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "postalCode")
+                .AddProperty(x => x.StreetCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "streetDetail", "code")
                 .AddProperty(x => x.CountryCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "townDetail", "country")
                 .AddProperty(x => x.IsWashable, IsWashable, "MarketEvaluationPoint", "usagePointLocation.officialAddressIndicator")
                 .AddProperty(x => x.FromGrid, "MarketEvaluationPoint", "inMeteringGridArea_Domain.mRID")

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
@@ -45,6 +45,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 .AddProperty(x => x.PostCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "postalCode")
                 .AddProperty(x => x.StreetCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "streetDetail", "code")
                 .AddProperty(x => x.CountryCode, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "townDetail", "country")
+                .AddProperty(x => x.FloorIdentification, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "streetDetail", "floorIdentification")
+                .AddProperty(x => x.RoomIdentification, "MarketEvaluationPoint", "usagePointLocation.mainAddress", "streetDetail", "suiteNumber")
                 .AddProperty(x => x.IsWashable, IsWashable, "MarketEvaluationPoint", "usagePointLocation.officialAddressIndicator")
                 .AddProperty(x => x.FromGrid, "MarketEvaluationPoint", "inMeteringGridArea_Domain.mRID")
                 .AddProperty(x => x.ToGrid, "MarketEvaluationPoint", "outMeteringGridArea_Domain.mRID")

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
@@ -46,6 +46,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Ingestion.Mappers
                         CityName = obj.CityName,
                         CountryCode = obj.CountryCode,
                         IsWashable = obj.IsWashable,
+                        StreetCode = obj.StreetCode,
                     },
                     SettlementMethod = obj.SettlementMethod,
                     UnitType = obj.UnitType,

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
@@ -47,6 +47,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Ingestion.Mappers
                         CountryCode = obj.CountryCode,
                         IsWashable = obj.IsWashable,
                         StreetCode = obj.StreetCode,
+                        FloorIdentification = obj.FloorIdentification,
+                        RoomIdentification = obj.RoomIdentification,
                     },
                     SettlementMethod = obj.SettlementMethod,
                     UnitType = obj.UnitType,

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
@@ -25,6 +25,7 @@ message Address {
   string cityName = 3;
   string countryCode = 4;
   bool isWashable = 5;
+  string streetCode = 6;
 }
 
 message CreateMeteringPoint {

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
@@ -25,7 +25,9 @@ message Address {
   string cityName = 3;
   string countryCode = 4;
   bool isWashable = 5;
-  string streetCode = 6;
+  string streetCode = 7;
+  string floorIdentification = 8;
+  string roomIdentification = 9;
 }
 
 message CreateMeteringPoint {

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
@@ -30,6 +30,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Processing.Mappers
                 PostCode: obj.InstallationLocationAddress.PostCode,
                 CityName: obj.InstallationLocationAddress.CityName,
                 CountryCode: obj.InstallationLocationAddress.CountryCode,
+                StreetCode: obj.InstallationLocationAddress.StreetCode,
                 IsWashable: obj.InstallationLocationAddress.IsWashable,
                 GsrnNumber: obj.GsrnNumber,
                 TypeOfMeteringPoint: obj.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
@@ -31,6 +31,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Processing.Mappers
                 CityName: obj.InstallationLocationAddress.CityName,
                 CountryCode: obj.InstallationLocationAddress.CountryCode,
                 StreetCode: obj.InstallationLocationAddress.StreetCode,
+                FloorIdentification: obj.InstallationLocationAddress.FloorIdentification,
+                RoomIdentification: obj.InstallationLocationAddress.RoomIdentification,
                 IsWashable: obj.InstallationLocationAddress.IsWashable,
                 GsrnNumber: obj.GsrnNumber,
                 TypeOfMeteringPoint: obj.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
@@ -88,6 +88,8 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.ConnectMeteringPoint
                 SampleData.CityName,
                 SampleData.CountryCode,
                 SampleData.StreetCode,
+                SampleData.FloorIdentification,
+                SampleData.RoomIdentification,
                 SampleData.IsWashable,
                 SampleData.GsrnNumber,
                 SampleData.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
@@ -87,6 +87,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.ConnectMeteringPoint
                 SampleData.PostCode,
                 SampleData.CityName,
                 SampleData.CountryCode,
+                SampleData.StreetCode,
                 SampleData.IsWashable,
                 SampleData.GsrnNumber,
                 SampleData.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -140,6 +140,8 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
                 SampleData.CityName,
                 SampleData.CountryCode,
                 SampleData.StreetCode,
+                SampleData.FloorIdentification,
+                SampleData.RoomIdentification,
                 SampleData.IsWashable,
                 SampleData.GsrnNumber,
                 SampleData.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -139,6 +139,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
                 SampleData.PostCode,
                 SampleData.CityName,
                 SampleData.CountryCode,
+                SampleData.StreetCode,
                 SampleData.IsWashable,
                 SampleData.GsrnNumber,
                 SampleData.TypeOfMeteringPoint,

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/SampleData.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/SampleData.cs
@@ -53,6 +53,8 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
 
         public static string CountryCode => "DK";
 
+        public static string StreetCode => "9999";
+
         public static bool IsWashable => true;
 
         public static string MeterNumber => "12345678910";

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/SampleData.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/SampleData.cs
@@ -60,5 +60,9 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
         public static string MeterNumber => "12345678910";
 
         public static string NetSettlementGroup => Domain.MeteringPoints.NetSettlementGroup.Zero.Name;
+
+        public static string FloorIdentification => string.Empty;
+
+        public static string RoomIdentification => string.Empty;
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -248,7 +248,42 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
         {
             var businessRequest = CreateRequest() with
             {
+                GsrnNumber = SampleData.GsrnNumber,
                 StreetCode = streetCode,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData("", typeof(FloorIdentificationValidationError), false)]
+        [InlineData("2", typeof(FloorIdentificationValidationError), false)]
+        [InlineData("A", typeof(FloorIdentificationValidationError), false)]
+        [InlineData("ABCDE", typeof(FloorIdentificationValidationError), true)]
+        [InlineData("12345", typeof(FloorIdentificationValidationError), true)]
+        public void Validate_FloorIdentification(string floorIdentification, System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                GsrnNumber = SampleData.GsrnNumber,
+                FloorIdentification = floorIdentification,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData("", typeof(RoomIdentificationValidationError), false)]
+        [InlineData("2", typeof(RoomIdentificationValidationError), false)]
+        [InlineData("A", typeof(RoomIdentificationValidationError), false)]
+        [InlineData("ABCDE", typeof(RoomIdentificationValidationError), true)]
+        [InlineData("12345", typeof(RoomIdentificationValidationError), true)]
+        public void Validate_RoomIdentification(string roomIdentification, System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                GsrnNumber = SampleData.GsrnNumber,
+                RoomIdentification = roomIdentification,
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using Energinet.DataHub.MeteringPoints.Application;
 using Energinet.DataHub.MeteringPoints.Application.Validation;
 using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using FluentAssertions;
 using Xunit;
@@ -284,6 +285,25 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
             {
                 GsrnNumber = SampleData.GsrnNumber,
                 RoomIdentification = roomIdentification,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Ninetynine), typeof(NetSettlementGroupMandatoryValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(NetSettlementGroup.Ninetynine), typeof(NetSettlementGroupMandatoryValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), "InvalidNetSettlementGroupValue", typeof(NetSettlementGroupInvalidValueValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Exchange), nameof(NetSettlementGroup.Ninetynine), typeof(NetSettlementGroupNotAllowedValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Consumption), "", typeof(NetSettlementGroupMandatoryValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Production), "", typeof(NetSettlementGroupMandatoryValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Exchange), "", typeof(NetSettlementGroupMandatoryValidationError), false)]
+        public void Validate_NetSettlementGroup(string meteringPointType, string netSettlementGroup, System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                NetSettlementGroup = netSettlementGroup,
+                TypeOfMeteringPoint = meteringPointType,
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -183,6 +183,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
                 CityName = cityName,
                 GsrnNumber = SampleData.GsrnNumber,
                 TypeOfMeteringPoint = typeOfMeteringPoint,
+                StreetCode = "9999",
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
@@ -229,6 +230,25 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
             {
                 GsrnNumber = SampleData.GsrnNumber,
                 SubTypeOfMeteringPoint = subTypeOfMeteringPoint,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData("1234", typeof(StreetCodeValidationError), false)]
+        [InlineData("0000", typeof(StreetCodeValidationError), true)]
+        [InlineData("0001", typeof(StreetCodeValidationError), false)]
+        [InlineData("00011", typeof(StreetCodeValidationError), true)]
+        [InlineData("12345", typeof(StreetCodeValidationError), true)]
+        [InlineData("9999", typeof(StreetCodeValidationError), false)]
+        [InlineData("9", typeof(StreetCodeValidationError), true)]
+        [InlineData("afsd", typeof(StreetCodeValidationError), true)]
+        public void Validate_StreetCode(string streetCode, System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                StreetCode = streetCode,
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

Added following Input Validations:

- The street code of a metering point consists of exactly 4 digits in the range 0001 to 9999
- The floor identification of a metering point consists of maximal 4 characters
- The room identification of a metering point consists of maximal 4 characters
- The net settlement group of a metering point is mandatory for Consumption and Production MPs, otherwise not allowed
- The net settlement group of a metering point has domain values 0, 1, 2, 3, 6, and 99

Missing correct codes in Error Converters.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
