### PR TITLE
Add validations for capacity

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
@@ -52,6 +52,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
             string ToGrid = "",
             string ParentRelatedMeteringPoint = "",
             string ProductType = "",
+            string? PhysicalConnectionCapacity = null,
             string MeasureUnitType = "")
         : IBusinessRequest,
             IOutboundMessage,

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
@@ -32,6 +32,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation
             RuleFor(request => request).SetValidator(new NetSettlementGroupRule());
             RuleFor(request => request).SetValidator(new ProductTypeRule());
             RuleFor(request => request).SetValidator(new MeasureUnitTypeRule());
+            RuleFor(request => request).SetValidator(new CapacityRule());
             RuleFor(request => request).SetValidator(new LocationDescriptionMustBeValidRule());
             RuleFor(request => request).SetValidator(new PowerPlantMustBeValidRule());
         }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/CapacityRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/CapacityRule.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Globalization;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using FluentValidation;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
+{
+    public class CapacityRule : AbstractValidator<CreateMeteringPoint>
+    {
+        private const int CapacityMaximumLength = 8;
+
+        public CapacityRule()
+        {
+            When(IsProductionOrConsumptionWithNetSettlementGroupNotZero, () =>
+            {
+                RuleFor(request => request.PhysicalConnectionCapacity)
+                    .Must(capacity => !string.IsNullOrWhiteSpace(capacity))
+                    .WithState(request => new CapacityIsMandatoryValidationError(request.GsrnNumber, request.PhysicalConnectionCapacity));
+            });
+
+            When(IsNotAllowedType, () =>
+            {
+                RuleFor(request => request.PhysicalConnectionCapacity)
+                    .Null()
+                    .WithState(request => new CapacityIsNotAllowedValidationError(request.GsrnNumber, request.PhysicalConnectionCapacity));
+            });
+
+            When(request => request.PhysicalConnectionCapacity?.Length > 0, () =>
+            {
+                CascadeMode = CascadeMode.Stop;
+
+                RuleFor(request => request.PhysicalConnectionCapacity)
+                    .MaximumLength(CapacityMaximumLength)
+                    .WithState(request => new CapacityMaximumLengthValidationError(request.GsrnNumber, request.PhysicalConnectionCapacity))
+                    .Must(capacity => float.TryParse(capacity, NumberStyles.AllowDecimalPoint, NumberFormatInfo.InvariantInfo, out _))
+                    .WithState(request => new CapacityMaximumLengthValidationError(request.GsrnNumber, request.PhysicalConnectionCapacity));
+            });
+        }
+
+        private static bool IsProductionOrConsumptionWithNetSettlementGroupNotZero(CreateMeteringPoint request)
+        {
+            return request.TypeOfMeteringPoint == MeteringPointType.Production.Name ||
+                   (request.TypeOfMeteringPoint == MeteringPointType.Consumption.Name && request.NetSettlementGroup != NetSettlementGroup.Zero.Name);
+        }
+
+        private static bool IsNotAllowedType(CreateMeteringPoint request)
+        {
+            var notAllowedMeteringPointTypes = new HashSet<string>
+            {
+                MeteringPointType.Exchange.Name,
+                MeteringPointType.Analysis.Name,
+                MeteringPointType.NetConsumption.Name,
+                MeteringPointType.ExchangeReactiveEnergy.Name,
+                MeteringPointType.InternalUse.Name,
+            };
+
+            return notAllowedMeteringPointTypes.Contains(request.TypeOfMeteringPoint);
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityIsMandatoryValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityIsMandatoryValidationError.cs
@@ -16,16 +16,16 @@ using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
 {
-    public class ProductTypeInvalidValueValidationError : ValidationError
+    public class CapacityIsMandatoryValidationError : ValidationError
     {
-        public ProductTypeInvalidValueValidationError(string gsrnNumber, string productType)
+        public CapacityIsMandatoryValidationError(string gsrnNumber, string? capacity)
         {
             GsrnNumber = gsrnNumber;
-            ProductType = productType;
+            Capacity = capacity;
         }
 
         public string GsrnNumber { get; }
 
-        public string ProductType { get; }
+        public string? Capacity { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityIsNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityIsNotAllowedValidationError.cs
@@ -16,16 +16,16 @@ using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
 {
-    public class ProductTypeInvalidValueValidationError : ValidationError
+    public class CapacityIsNotAllowedValidationError : ValidationError
     {
-        public ProductTypeInvalidValueValidationError(string gsrnNumber, string productType)
+        public CapacityIsNotAllowedValidationError(string gsrnNumber, string? capacity)
         {
             GsrnNumber = gsrnNumber;
-            ProductType = productType;
+            Capacity = capacity;
         }
 
         public string GsrnNumber { get; }
 
-        public string ProductType { get; }
+        public string? Capacity { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityMaximumLengthValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CapacityMaximumLengthValidationError.cs
@@ -16,16 +16,16 @@ using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
 {
-    public class ProductTypeInvalidValueValidationError : ValidationError
+    public class CapacityMaximumLengthValidationError : ValidationError
     {
-        public ProductTypeInvalidValueValidationError(string gsrnNumber, string productType)
+        public CapacityMaximumLengthValidationError(string gsrnNumber, string? capacity)
         {
             GsrnNumber = gsrnNumber;
-            ProductType = productType;
+            Capacity = capacity;
         }
 
         public string GsrnNumber { get; }
 
-        public string ProductType { get; }
+        public string? Capacity { get; }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityIsMandatoryErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityIsMandatoryErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class CapacityIsMandatoryErrorConverter : ErrorConverter<CapacityIsMandatoryValidationError>
+    {
+        protected override ErrorMessage Convert(CapacityIsMandatoryValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new("D56", $"Capacity '{validationError.Capacity}' for metering point {validationError.GsrnNumber} with net settlement group not 0 is missing (type E18) or not allowed (other types).");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityIsNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityIsNotAllowedErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class CapacityIsNotAllowedErrorConverter : ErrorConverter<CapacityIsNotAllowedValidationError>
+    {
+        protected override ErrorMessage Convert(CapacityIsNotAllowedValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new("D56", $"Capacity '{validationError.Capacity}' for metering point {validationError.GsrnNumber} with net settlement group not 0 is missing (type E18) or not allowed (other types).");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityMaximumLengthErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/CapacityMaximumLengthErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class CapacityMaximumLengthErrorConverter : ErrorConverter<CapacityMaximumLengthValidationError>
+    {
+        protected override ErrorMessage Convert(CapacityMaximumLengthValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new("E86", $"Capacity '{validationError.Capacity}' for metering point {validationError.GsrnNumber} contains a non-digit character other than a decimal point or has a length that exceeds 8.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/ConverterMapperConfigurationBuilder.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/ConverterMapperConfigurationBuilder.cs
@@ -49,7 +49,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter
             return AddPropertyInternal(selector, CastFunc(translatorFunc), xmlHierarchy);
         }
 
-        public ConverterMapperConfigurationBuilder<T> AddProperty(Expression<Func<T, string>> selector, params string[] xmlHierarchy)
+        public ConverterMapperConfigurationBuilder<T> AddProperty(Expression<Func<T, string?>> selector, params string[] xmlHierarchy)
         {
             return AddPropertyInternal(selector, xmlHierarchy);
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
@@ -55,6 +55,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 .AddProperty(x => x.ToGrid, "MarketEvaluationPoint", "outMeteringGridArea_Domain.mRID")
                 .AddProperty(x => x.ParentRelatedMeteringPoint, "MarketEvaluationPoint", "parent_MarketEvaluationPoint.mRID")
                 .AddProperty(x => x.ProductType, TranslateProductType, "MarketEvaluationPoint", "Series", "product")
+                .AddProperty(x => x.PhysicalConnectionCapacity, "MarketEvaluationPoint", "physicalConnectionCapacity")
                 .AddProperty(x => x.MeasureUnitType, TranslateMeasureUnitType, "MarketEvaluationPoint", "Series", "quantity_Measure_Unit.name"));
         }
 
@@ -70,6 +71,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 "D01" => nameof(SettlementMethod.Flex),
                 "E02" => nameof(SettlementMethod.NonProfiled),
                 "E01" => nameof(SettlementMethod.Profiled),
+                // TODO: don't return empty string.
+                // TODO: Pass through original value instead.
                 _ => string.Empty,
             };
         }
@@ -207,7 +210,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 "8716867000023" => nameof(ProductType.PowerReactive),
                 "5790001330606" => nameof(ProductType.FuelQuantity),
                 "5790001330590" => nameof(ProductType.Tariff),
-                _ => string.Empty,
+                _ => productType.SourceValue,
             };
         }
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -60,10 +60,6 @@ limitations under the License.
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Energinet.DataHub.MeteringPoints.Application\Energinet.DataHub.MeteringPoints.Application.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
       <Folder Include="Messaging\Incoming\Protobuf\Contracts" />
     </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Ingestion/Mappers/CreateMeteringPointMapper.cs
@@ -68,6 +68,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Ingestion.Mappers
                     ToGrid = obj.ToGrid,
                     ProductType = obj.ProductType,
                     MeasureUnitType = obj.MeasureUnitType,
+                    PhysicalConnectionCapacity = obj.PhysicalConnectionCapacity,
                 },
             };
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
@@ -60,6 +60,7 @@ message CreateMeteringPoint {
   string toGrid = 23;
   string productType = 24;
   string measureUnitType = 25;
+  google.protobuf.StringValue physicalConnectionCapacity = 26;
 }
 
 message ConnectMeteringPoint {

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Mappers/CreateMeteringPointMapper.cs
@@ -60,7 +60,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Processing.Mappers
                 FromGrid: obj.FromGrid,
                 ToGrid: obj.ToGrid,
                 ProductType: obj.ProductType,
-                MeasureUnitType: obj.MeasureUnitType);
+                MeasureUnitType: obj.MeasureUnitType,
+                PhysicalConnectionCapacity: obj.PhysicalConnectionCapacity);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ConnectMeteringPoints/ConnectTests.cs
@@ -117,6 +117,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.ConnectMeteringPoint
                 ToGrid: string.Empty,
                 ParentRelatedMeteringPoint: string.Empty,
                 SampleData.ProductType,
+                null,
                 SampleData.MeasurementUnitType);
         }
 

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -169,6 +169,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
                 ToGrid: "456",
                 ParentRelatedMeteringPoint: string.Empty,
                 SampleData.ProductType,
+                null,
                 SampleData.MeasurementUnitType);
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CapacityRuleTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CapacityRuleTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application;
+using Energinet.DataHub.MeteringPoints.Application.Validation.Rules;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using FluentAssertions;
+using Xunit;
+using Xunit.Categories;
+
+namespace Energinet.DataHub.MeteringPoints.Tests.Validation
+{
+    [UnitTest]
+    public class CapacityRuleTests : RuleSetTest<CreateMeteringPoint, CapacityRule>
+    {
+        [Theory]
+        [InlineData("12345678", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One))]
+        [InlineData("2234.567", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One))]
+        [InlineData("32345678", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero))]
+        [InlineData("42345678", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.One))]
+        [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero))]
+        [InlineData(null, nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero))]
+        public void CapacityShouldValidate(string capacity, string meteringPointType, string netSettlementGroup)
+        {
+            var request = CreateRequest() with
+            {
+                NetSettlementGroup = netSettlementGroup,
+                PhysicalConnectionCapacity = capacity,
+                TypeOfMeteringPoint = meteringPointType,
+            };
+
+            var errors = Validate(request);
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("423456789", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityMaximumLengthValidationError))]
+        [InlineData("5234.5678", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityMaximumLengthValidationError))]
+        [InlineData("1,2", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityMaximumLengthValidationError))]
+        [InlineData("1.2.3", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityMaximumLengthValidationError))]
+
+        [InlineData(null, nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityIsMandatoryValidationError))]
+        [InlineData("", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(CapacityIsMandatoryValidationError))]
+        [InlineData(null, nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.One), typeof(CapacityIsMandatoryValidationError))]
+        [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.One), typeof(CapacityIsMandatoryValidationError))]
+
+        [InlineData("", nameof(MeteringPointType.Exchange), nameof(NetSettlementGroup.One), typeof(CapacityIsNotAllowedValidationError))]
+        [InlineData("", nameof(MeteringPointType.Analysis), nameof(NetSettlementGroup.One), typeof(CapacityIsNotAllowedValidationError))]
+        [InlineData("", nameof(MeteringPointType.NetConsumption), nameof(NetSettlementGroup.One), typeof(CapacityIsNotAllowedValidationError))]
+        [InlineData("", nameof(MeteringPointType.ExchangeReactiveEnergy), nameof(NetSettlementGroup.One), typeof(CapacityIsNotAllowedValidationError))]
+        [InlineData("", nameof(MeteringPointType.InternalUse), nameof(NetSettlementGroup.One), typeof(CapacityIsNotAllowedValidationError))]
+        public void CapacityShouldResultInError(string capacity, string meteringPointType, string netSettlementGroup, Type expectedError)
+        {
+            var request = CreateRequest() with
+            {
+                NetSettlementGroup = netSettlementGroup,
+                PhysicalConnectionCapacity = capacity,
+                TypeOfMeteringPoint = meteringPointType,
+            };
+
+            var errors = Validate(request);
+
+            errors.Should().ContainSingle(error => error.GetType() == expectedError);
+        }
+
+        private static CreateMeteringPoint CreateRequest()
+        {
+            return new();
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using FluentAssertions;
+using FluentValidation;
 using Xunit;
 using Xunit.Categories;
 

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/RuleSetTest.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/RuleSetTest.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Application;
+using Energinet.DataHub.MeteringPoints.Application.Validation;
+using Energinet.DataHub.MeteringPoints.Application.Validation.Rules;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+using FluentAssertions;
+using FluentValidation;
+using Xunit;
+using Xunit.Categories;
+
+namespace Energinet.DataHub.MeteringPoints.Tests.Validation
+{
+    public abstract class RuleSetTest<TRequest, TRuleSet>
+        where TRuleSet : AbstractValidator<TRequest>, new()
+    {
+        protected IReadOnlyCollection<ValidationError> Validate(TRequest request)
+        {
+            var validationResult = new RuleSet().Validate(request);
+
+            return validationResult.Errors
+                .Select(error => (ValidationError)error.CustomState)
+                .ToList();
+        }
+
+        private class RuleSet : AbstractValidator<TRequest>
+        {
+            public RuleSet()
+            {
+                RuleFor(request => request).SetValidator(new TRuleSet());
+            }
+        }
+    }
+}


### PR DESCRIPTION
- The capacity of a metering point consists of maximal 8 characters. Only digits and an optional decimal point are allowed. (only . allowed) (physical)
- The capacity of Production metering points is mandatory (physical)
- The capacity of consumption metering points is mandatory if net settlement group is not 0, else optional (physical)
- The capacity field is not allowed for MP Types: E20, D02, D15, D20, D99 (physical)

Also, introduce separate test files for rule sets.

