### PR TITLE
Power plant and sub type rules

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringPointSubTypeMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringPointSubTypeMustBeValidRule.cs
@@ -27,16 +27,105 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 .NotEmpty()
                 .WithState(createMeteringPoint => new MeteringPointSubTypeMandatoryValidationError(createMeteringPoint.GsrnNumber));
 
-            RuleFor(createMeteringPoint => createMeteringPoint.SubTypeOfMeteringPoint)
+            RuleFor(createMeteringPoint => createMeteringPoint)
                 .Must(SubTypeIsPhysicalOrVirtualOrCalculated)
                 .WithState(createMeteringPoint => new MeteringPointSubTypeValueMustBeValidValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.SubTypeOfMeteringPoint));
         }
 
-        private static bool SubTypeIsPhysicalOrVirtualOrCalculated(string subTypeOfMeteringPoint)
+        private static bool GroupOfMeteringPointTypesThatMustBeSubTypeVirtualOrCalculated(CreateMeteringPoint createMeteringPoint)
         {
-            return Physical(subTypeOfMeteringPoint) ||
-                   Virtual(subTypeOfMeteringPoint) ||
-                   Calculated(subTypeOfMeteringPoint);
+            return IsWholeSaleServices(createMeteringPoint) ||
+                   IsOwnProduction(createMeteringPoint) ||
+                   IsNetFromGrid(createMeteringPoint) ||
+                   IsNetToGrid(createMeteringPoint) ||
+                   IsTotalConsumption(createMeteringPoint) ||
+                   MeteringPointTypeConsumptionOrProductionIsNotInNetSettlementZeroOrNinetyNine(createMeteringPoint);
+        }
+
+        private static bool MeteringPointTypeConsumptionOrProductionIsNotInNetSettlementZeroOrNinetyNine(
+            CreateMeteringPoint createMeteringPoint)
+        {
+            return (
+                    IsConsumption(createMeteringPoint) ||
+                    IsProduction(createMeteringPoint)) &&
+                    NetSettlementGroupIsNotZeroOrNinetyNine(createMeteringPoint.NetSettlementGroup);
+        }
+
+        private static bool IsProduction(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.Production.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsConsumption(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.Consumption.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool NetSettlementGroupIsNotZeroOrNinetyNine(string netSettlement)
+        {
+            return netSettlement.Equals(
+                NetSettlementGroup.Ninetynine.Name,
+                StringComparison.Ordinal) ||
+                netSettlement.Equals(
+                NetSettlementGroup.Zero.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool SubTypeIsPhysicalOrVirtualOrCalculated(CreateMeteringPoint createMeteringPoint)
+        {
+            if (GroupOfMeteringPointTypesThatMustBeSubTypeVirtualOrCalculated(createMeteringPoint))
+            {
+                return SubTypeIsVirtualOrCalculated(createMeteringPoint);
+            }
+
+            return Physical(createMeteringPoint.SubTypeOfMeteringPoint) ||
+                   Virtual(createMeteringPoint.SubTypeOfMeteringPoint) ||
+                   Calculated(createMeteringPoint.SubTypeOfMeteringPoint);
+        }
+
+        private static bool SubTypeIsVirtualOrCalculated(CreateMeteringPoint createMeteringPoint)
+        {
+            return Virtual(createMeteringPoint.SubTypeOfMeteringPoint) ||
+                   Calculated(createMeteringPoint.SubTypeOfMeteringPoint);
+        }
+
+        private static bool IsWholeSaleServices(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.WholesaleServices.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsOwnProduction(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.OwnProduction.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsNetFromGrid(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.NetFromGrid.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsNetToGrid(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.NetToGrid.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsTotalConsumption(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.TypeOfMeteringPoint.Equals(
+                MeteringPointType.TotalConsumption.Name,
+                StringComparison.Ordinal);
         }
 
         private static bool Physical(string subTypeOfMeteringPoint)

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringPointSubTypeMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringPointSubTypeMustBeValidRule.cs
@@ -48,7 +48,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
             return (
                     IsConsumption(createMeteringPoint) ||
                     IsProduction(createMeteringPoint)) &&
-                    NetSettlementGroupIsNotZeroOrNinetyNine(createMeteringPoint.NetSettlementGroup);
+                    !NetSettlementGroupIsZeroOrNinetyNine(createMeteringPoint.NetSettlementGroup);
         }
 
         private static bool IsProduction(CreateMeteringPoint createMeteringPoint)
@@ -65,7 +65,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 StringComparison.Ordinal);
         }
 
-        private static bool NetSettlementGroupIsNotZeroOrNinetyNine(string netSettlement)
+        private static bool NetSettlementGroupIsZeroOrNinetyNine(string netSettlement)
         {
             return netSettlement.Equals(
                 NetSettlementGroup.Ninetynine.Name,

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/PowerPlantMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/PowerPlantMustBeValidRule.cs
@@ -55,7 +55,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
         {
             return IsProduction(createMeteringPoint) ||
                    IsVeProduction(createMeteringPoint) ||
-                   IsConsumptionAndNotZero(createMeteringPoint);
+                   IsConsumptionAndNotZeroOrNinetyNine(createMeteringPoint);
         }
 
         private static bool IsAnalysis(CreateMeteringPoint createMeteringPoint)
@@ -93,14 +93,32 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 StringComparison.Ordinal);
         }
 
-        private static bool IsConsumptionAndNotZero(CreateMeteringPoint createMeteringPoint)
+        private static bool IsConsumptionAndNotZeroOrNinetyNine(CreateMeteringPoint createMeteringPoint)
+        {
+            return IsConsumption(createMeteringPoint) &&
+             !IsNetSettlementGroupZero(createMeteringPoint) &&
+             !IsNetSettlementGroupNinetyNine(createMeteringPoint);
+        }
+
+        private static bool IsConsumption(CreateMeteringPoint createMeteringPoint)
         {
             return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                 MeteringPointType.Consumption.Name,
-                 StringComparison.Ordinal) &&
-             !createMeteringPoint.NetSettlementGroup.Equals(
-                 NetSettlementGroup.Zero.Name,
-                 StringComparison.Ordinal);
+                MeteringPointType.Consumption.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsNetSettlementGroupZero(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.NetSettlementGroup.Equals(
+                NetSettlementGroup.Zero.Name,
+                StringComparison.Ordinal);
+        }
+
+        private static bool IsNetSettlementGroupNinetyNine(CreateMeteringPoint createMeteringPoint)
+        {
+            return createMeteringPoint.NetSettlementGroup.Equals(
+                       NetSettlementGroup.Ninetynine.Name,
+                       StringComparison.Ordinal);
         }
 
         private static bool PowerPlantNotAllowedGroupOfMeteringPointTypes(CreateMeteringPoint createMeteringPoint)

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/PowerPlantMustBeValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/PowerPlantMustBeValidRule.cs
@@ -13,6 +13,7 @@
 // // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Data;
 using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
@@ -27,70 +28,25 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
         public PowerPlantMustBeValidRule()
         {
             When(
-                PowerPlantMustNotBeEmptyGroupOfMeteringPointTypes,
+                MandatoryGroupOfMeteringPointTypes,
                 PowerPlantMustNotBeEmpty);
             When(
-                PowerPlantNotAllowedGroupOfMeteringPointTypes,
+                NotAllowedGroupOfMeteringPointTypes,
                 PowerPlantMustBeEmpty);
             When(
                 createMeteringPoint => createMeteringPoint.PowerPlant.Length > 0,
                 PowerPlantValueMustBeValid);
         }
 
-        private static bool IsVeProduction(CreateMeteringPoint createMeteringPoint)
+        private static bool MandatoryGroupOfMeteringPointTypes(CreateMeteringPoint createMeteringPoint)
         {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.VEProduction.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool IsProduction(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.Production.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool PowerPlantMustNotBeEmptyGroupOfMeteringPointTypes(CreateMeteringPoint createMeteringPoint)
-        {
-            return IsProduction(createMeteringPoint) ||
-                   IsVeProduction(createMeteringPoint) ||
-                   IsConsumptionAndNotZeroOrNinetyNine(createMeteringPoint);
-        }
-
-        private static bool IsAnalysis(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.Analysis.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool IsInternalUse(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.InternalUse.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool IsNetConsumption(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.NetConsumption.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool IsExchangeReactiveEnergy(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.ExchangeReactiveEnergy.Name,
-                StringComparison.Ordinal);
-        }
-
-        private static bool IsExchange(CreateMeteringPoint createMeteringPoint)
-        {
-            return createMeteringPoint.TypeOfMeteringPoint.Equals(
-                MeteringPointType.Exchange.Name,
-                StringComparison.Ordinal);
+            return new HashSet<string>
+                    {
+                        MeteringPointType.Production.Name,
+                        MeteringPointType.VEProduction.Name,
+                    }
+                .Contains(createMeteringPoint.TypeOfMeteringPoint) ||
+                IsConsumptionAndNotZeroOrNinetyNine(createMeteringPoint);
         }
 
         private static bool IsConsumptionAndNotZeroOrNinetyNine(CreateMeteringPoint createMeteringPoint)
@@ -121,13 +77,17 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                        StringComparison.Ordinal);
         }
 
-        private static bool PowerPlantNotAllowedGroupOfMeteringPointTypes(CreateMeteringPoint createMeteringPoint)
+        private static bool NotAllowedGroupOfMeteringPointTypes(CreateMeteringPoint createMeteringPoint)
         {
-            return IsAnalysis(createMeteringPoint) ||
-                   IsInternalUse(createMeteringPoint) ||
-                   IsNetConsumption(createMeteringPoint) ||
-                   IsExchangeReactiveEnergy(createMeteringPoint) ||
-                   IsExchange(createMeteringPoint);
+            return new HashSet<string>
+                    {
+                        MeteringPointType.Analysis.Name,
+                        MeteringPointType.Exchange.Name,
+                        MeteringPointType.ExchangeReactiveEnergy.Name,
+                        MeteringPointType.InternalUse.Name,
+                        MeteringPointType.NetConsumption.Name,
+                    }
+                .Contains(createMeteringPoint.TypeOfMeteringPoint);
         }
 
         private static int Parse(string input)
@@ -168,7 +128,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
 
         private void PowerPlantMustBeEmpty()
         {
-            RuleFor(createmeteringPoint => createmeteringPoint.PowerPlant)
+            RuleFor(createMeteringPoint => createMeteringPoint.PowerPlant)
                 .Empty()
                 .WithState(createMeteringPoint => new PowerPlantValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.PowerPlant));
         }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -434,6 +434,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
         [InlineData("", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(PowerPlantValidationError), true)]
         [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.One), typeof(PowerPlantValidationError), true)]
         [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero), typeof(PowerPlantGsrnEan18ValidValidationError), false)]
+        [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Ninetynine), typeof(PowerPlantGsrnEan18ValidValidationError), false)]
         public void Validate_PowerPlant(string powerPlant, string meteringPointType, string netSettlementGroup,  System.Type validationError, bool expectedError)
         {
             var businessRequest = CreateRequest() with
@@ -467,16 +468,32 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
         }
 
         [Theory]
-        [InlineData(nameof(MeteringPointSubType.Physical), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
-        [InlineData(nameof(MeteringPointSubType.Virtual), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
-        [InlineData(nameof(MeteringPointSubType.Calculated), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
-        [InlineData("", typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
-        public void Validate_MeteringPoint_Subtype_Correct_Value(string meteringPointSubType,  System.Type validationError, bool expectedError)
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.One),  typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.WholesaleServices), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.OwnProduction), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.NetFromGrid), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.NetToGrid), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.TotalConsumption), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Consumption), "", nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.WholesaleServices), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.OwnProduction), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.NetFromGrid), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.NetToGrid), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.TotalConsumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Zero), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Ninetynine), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.Zero), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.Ninetynine), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        public void Validate_MeteringPoint_Subtype_Correct_Value(string typeOfMeteringPoint, string meteringPointSubType, string netSettlementGroup,  System.Type validationError, bool expectedError)
         {
             var businessRequest = CreateRequest() with
             {
                 GsrnNumber = SampleData.GsrnNumber,
+                TypeOfMeteringPoint = typeOfMeteringPoint,
                 SubTypeOfMeteringPoint = meteringPointSubType,
+                NetSettlementGroup = netSettlementGroup,
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -468,7 +468,6 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
         }
 
         [Theory]
-        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
         [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.One),  typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
         [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
         [InlineData(nameof(MeteringPointType.WholesaleServices), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
@@ -482,10 +481,12 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
         [InlineData(nameof(MeteringPointType.NetFromGrid), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
         [InlineData(nameof(MeteringPointType.NetToGrid), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
         [InlineData(nameof(MeteringPointType.TotalConsumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One),   typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
-        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Zero), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
-        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Ninetynine), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Zero), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.Ninetynine), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
         [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Virtual), nameof(NetSettlementGroup.Zero), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
         [InlineData(nameof(MeteringPointType.Production), nameof(MeteringPointSubType.Calculated), nameof(NetSettlementGroup.Ninetynine), typeof(MeteringPointSubTypeValueMustBeValidValidationError), false)]
+        [InlineData(nameof(MeteringPointType.Consumption), nameof(MeteringPointSubType.Physical), nameof(NetSettlementGroup.One), typeof(MeteringPointSubTypeValueMustBeValidValidationError), true)]
         public void Validate_MeteringPoint_Subtype_Correct_Value(string typeOfMeteringPoint, string meteringPointSubType, string netSettlementGroup,  System.Type validationError, bool expectedError)
         {
             var businessRequest = CreateRequest() with


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

- If a Consumption metering point (E17) is not in net settlement group 0 or 99 then a power plant is required.
- Meteringpoints of type D08, D09, D10, D11 and D12 must be Virtual (D02) or Calculated (D03).
- If a Consumption (E17) or Production (E18) metering point is not in net settlement group 0 or 99 then sub type must be Virtual (D02) or Calculated (D03).

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #71 
