### PR TITLE
Added input validations for source and target metering grid area

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringGridAreaValidRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/MeteringGridAreaValidRule.cs
@@ -25,7 +25,8 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
         public MeteringGridAreaValidRule()
         {
             MandatoryMeteringGridArea();
-            MeteringGridAreaLengthOf3Digits();
+            MeteringGridAreaLengthOfNDigits();
+            SourceAndTargetMeteringGridAreaNotAllowedForExchangeReactiveEnergy();
         }
 
         private void MandatoryMeteringGridArea()
@@ -35,11 +36,25 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
                 .WithState(createMeteringPoint => new MeteringGridAreaMandatoryValidationError(createMeteringPoint.GsrnNumber));
         }
 
-        private void MeteringGridAreaLengthOf3Digits()
+        private void MeteringGridAreaLengthOfNDigits()
         {
             RuleFor(createMeteringPoint => createMeteringPoint.MeteringGridArea)
                 .Length(ExactGridAreaLengthAllowed)
                 .WithState(createMeteringPoint => new MeteringGridAreaLengthValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.MeteringGridArea, ExactGridAreaLengthAllowed));
+        }
+
+        private void SourceAndTargetMeteringGridAreaNotAllowedForExchangeReactiveEnergy()
+        {
+            When(createMeteringPoint => createMeteringPoint.TypeOfMeteringPoint == MeteringPointType.ExchangeReactiveEnergy.Name, () =>
+            {
+                RuleFor(createMeteringPoint => createMeteringPoint.FromGrid)
+                    .Empty()
+                    .WithState(createMeteringPoint => new SourceMeteringGridAreaNotAllowedValidationError(createMeteringPoint.GsrnNumber));
+
+                RuleFor(createMeteringPoint => createMeteringPoint.ToGrid)
+                    .Empty()
+                    .WithState(createMeteringPoint => new TargetMeteringGridAreaNotAllowedValidationError(createMeteringPoint.GsrnNumber));
+            });
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/SourceMeteringGridAreaNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/SourceMeteringGridAreaNotAllowedValidationError.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class SourceMeteringGridAreaNotAllowedValidationError : ValidationError
+    {
+        public SourceMeteringGridAreaNotAllowedValidationError(string gsrnNumber)
+        {
+            GsrnNumber = gsrnNumber;
+        }
+
+        public string GsrnNumber { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/TargetMeteringGridAreaNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/TargetMeteringGridAreaNotAllowedValidationError.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class TargetMeteringGridAreaNotAllowedValidationError : ValidationError
+    {
+        public TargetMeteringGridAreaNotAllowedValidationError(string gsrnNumber)
+        {
+            GsrnNumber = gsrnNumber;
+        }
+
+        public string GsrnNumber { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/SourceMeteringGridAreaNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/SourceMeteringGridAreaNotAllowedErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class SourceMeteringGridAreaNotAllowedErrorConverter : ErrorConverter<SourceMeteringGridAreaNotAllowedValidationError>
+    {
+        protected override ErrorMessage Convert(SourceMeteringGridAreaNotAllowedValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new ErrorMessage("D46", $"The source metering point grid area attribute of the request may not be provided for D20 metering point id {validationError.GsrnNumber}.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/TargetMeteringGridAreaNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/TargetMeteringGridAreaNotAllowedErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class TargetMeteringGridAreaNotAllowedErrorConverter : ErrorConverter<TargetMeteringGridAreaNotAllowedValidationError>
+    {
+        protected override ErrorMessage Convert(TargetMeteringGridAreaNotAllowedValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new ErrorMessage("D46", $"The target metering point grid area attribute of the request may not be provided for D20 metering point id {validationError.GsrnNumber}.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/CreateMeteringPointRuleSetTests.cs
@@ -20,7 +20,6 @@ using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using FluentAssertions;
-using FluentValidation;
 using Xunit;
 using Xunit.Categories;
 
@@ -478,6 +477,39 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Validation
             {
                 GsrnNumber = SampleData.GsrnNumber,
                 SubTypeOfMeteringPoint = meteringPointSubType,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData(nameof(MeteringPointType.Consumption), "gridArea", typeof(SourceMeteringGridAreaNotAllowedValidationError), false)]
+        [InlineData(nameof(MeteringPointType.ExchangeReactiveEnergy), "gridArea", typeof(SourceMeteringGridAreaNotAllowedValidationError), true)]
+        [InlineData(nameof(MeteringPointType.ExchangeReactiveEnergy), "", typeof(SourceMeteringGridAreaNotAllowedValidationError), false)]
+        public void Validate_SourceMeteringGridArea(string meteringPointType, string gridArea,  System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                GsrnNumber = SampleData.GsrnNumber,
+                TypeOfMeteringPoint = meteringPointType,
+                FromGrid = gridArea,
+            };
+
+            ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);
+        }
+
+        [Theory]
+        [InlineData(nameof(MeteringPointType.Consumption), "gridArea", typeof(TargetMeteringGridAreaNotAllowedValidationError), false)]
+        [InlineData(nameof(MeteringPointType.ExchangeReactiveEnergy), "gridArea", typeof(TargetMeteringGridAreaNotAllowedValidationError), true)]
+        [InlineData(nameof(MeteringPointType.ExchangeReactiveEnergy), "", typeof(TargetMeteringGridAreaNotAllowedValidationError), false)]
+
+        public void Validate_TargetMeteringGridArea(string meteringPointType, string gridArea,  System.Type validationError, bool expectedError)
+        {
+            var businessRequest = CreateRequest() with
+            {
+                GsrnNumber = SampleData.GsrnNumber,
+                TypeOfMeteringPoint = meteringPointType,
+                ToGrid = gridArea,
             };
 
             ValidateCreateMeteringPoint(businessRequest, validationError, expectedError);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

- It is not allowed to provide the source metering grid area if a metering point of type is Exchange - Reactive energy (D20).
- It is not allowed to provide the target metering grid area if a metering point of type is Exchange - Reactive energy (D20).

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
