### PR TITLE
Asset Type validations

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPoint.cs
@@ -47,7 +47,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
             string PhysicalStatusOfMeteringPoint = "",
             string NetSettlementGroup = "",
             string ConnectionType = "",
-            string AssetType = "",
+            string? AssetType = null,
             string FromGrid = "",
             string ToGrid = "",
             string ParentRelatedMeteringPoint = "",

--- a/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/CreateMeteringPointHandler.cs
@@ -135,7 +135,7 @@ namespace Energinet.DataHub.MeteringPoints.Application
                 EnumerationType.FromName<NetSettlementGroup>(request.NetSettlementGroup),
                 EnumerationType.FromName<DisconnectionType>(request.DisconnectionType),
                 EnumerationType.FromName<ConnectionType>(request.ConnectionType),
-                EnumerationType.FromName<AssetType>(request.AssetType),
+                assetType: !string.IsNullOrEmpty(request.AssetType) ? EnumerationType.FromName<AssetType>(request.AssetType) : null,
                 request.ParentRelatedMeteringPoint,
                 EnumerationType.FromName<ProductType>(request.ProductType));
         }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/CreateMeteringPointRuleSet.cs
@@ -35,6 +35,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation
             RuleFor(request => request).SetValidator(new CapacityRule());
             RuleFor(request => request).SetValidator(new LocationDescriptionMustBeValidRule());
             RuleFor(request => request).SetValidator(new PowerPlantMustBeValidRule());
+            RuleFor(request => request).SetValidator(new AssetTypeRule());
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AssetTypeRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/Rules/AssetTypeRule.cs
@@ -1,0 +1,89 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+using FluentValidation;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.Rules
+{
+    public class AssetTypeRule : AbstractValidator<CreateMeteringPoint>
+    {
+        public AssetTypeRule()
+        {
+            When(IsProduction, () =>
+            {
+                RuleFor(request => request.AssetType)
+                    .NotEmpty()
+                    .WithState(request => new AssetTypeMandatoryValidationError(request.GsrnNumber));
+            });
+
+            When(IsConsumptionWithNetSettlementGroupNotZero, () =>
+            {
+                RuleFor(request => request.AssetType)
+                    .NotEmpty()
+                    .WithState(request => new AssetTypeMandatoryValidationError(request.GsrnNumber));
+            });
+
+            When(IsNotAllowedType, () =>
+            {
+                RuleFor(request => request.AssetType)
+                    .Null()
+                    .WithState(request => new AssetTypeNotAllowedValidationError(request.GsrnNumber, request.AssetType));
+            });
+
+            RuleFor(request => request.AssetType)
+                .Must(IsNullOrEmptyOrValidDomainValue)
+                .WithState(request => new AssetTypeWrongValueValidationError(request.GsrnNumber, request.AssetType));
+        }
+
+        private static bool IsConsumptionWithNetSettlementGroupNotZero(CreateMeteringPoint request)
+        {
+            return request.TypeOfMeteringPoint == MeteringPointType.Consumption.Name && request.NetSettlementGroup != NetSettlementGroup.Zero.Name;
+        }
+
+        private static bool IsProduction(CreateMeteringPoint request)
+        {
+            return request.TypeOfMeteringPoint == MeteringPointType.Production.Name;
+        }
+
+        private static bool IsNullOrEmptyOrValidDomainValue(string? assetType)
+        {
+            if (string.IsNullOrEmpty(assetType)) return true;
+
+            var allAssetTypes = EnumerationType.GetAll<AssetType>().Select(x => x.Name).ToHashSet();
+
+            return allAssetTypes.Contains(assetType);
+        }
+
+        private static bool IsNotAllowedType(CreateMeteringPoint request)
+        {
+            var notAllowedMeteringPointTypes = new HashSet<string>
+            {
+                MeteringPointType.Analysis.Name,
+                MeteringPointType.ExchangeReactiveEnergy.Name,
+                MeteringPointType.InternalUse.Name,
+                MeteringPointType.Exchange.Name,
+                MeteringPointType.GridLossCorrection.Name,
+                MeteringPointType.ElectricalHeating.Name,
+                MeteringPointType.NetConsumption.Name,
+            };
+
+            return notAllowedMeteringPointTypes.Contains(request.TypeOfMeteringPoint);
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeMandatoryValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeMandatoryValidationError.cs
@@ -1,0 +1,28 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class AssetTypeMandatoryValidationError : ValidationError
+    {
+        public AssetTypeMandatoryValidationError(string gsrnNumber)
+        {
+            GsrnNumber = gsrnNumber;
+        }
+
+        public string GsrnNumber { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeNotAllowedValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeNotAllowedValidationError.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class AssetTypeWrongValueValidationError : ValidationError
+    {
+        public AssetTypeWrongValueValidationError(string gsrnNumber, string? assetType)
+        {
+            GsrnNumber = gsrnNumber;
+            AssetType = assetType;
+        }
+
+        public string GsrnNumber { get; }
+
+        public string? AssetType { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeWrongValueValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/AssetTypeWrongValueValidationError.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
+{
+    public class AssetTypeNotAllowedValidationError : ValidationError
+    {
+        public AssetTypeNotAllowedValidationError(string gsrnNumber, string? assetType)
+        {
+            GsrnNumber = gsrnNumber;
+            AssetType = assetType;
+        }
+
+        public string GsrnNumber { get; }
+
+        public string? AssetType { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ConsumptionMeteringPoint.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
         private NetSettlementGroup _netSettlementGroup;
         private DisconnectionType _disconnectionType;
         private ConnectionType _connectionType;
-        private AssetType _assetType;
+        private AssetType? _assetType;
         private bool _isAddressWashable;
 
         public ConsumptionMeteringPoint(
@@ -47,7 +47,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             NetSettlementGroup netSettlementGroup,
             DisconnectionType disconnectionType,
             ConnectionType connectionType,
-            AssetType assetType,
+            AssetType? assetType,
             string? parentRelatedMeteringPoint,
             ProductType productType)
             : base(

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeMandatoryErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeMandatoryErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class AssetTypeMandatoryErrorConverter : ErrorConverter<AssetTypeMandatoryValidationError>
+    {
+        protected override ErrorMessage Convert(AssetTypeMandatoryValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new("D59", $"AssetType for metering point {validationError.GsrnNumber} is missing. It must be applied for Production (E18) and Consumption (E17) in net settlement groups other than 0.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeNotAllowedErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeNotAllowedErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class AssetTypeNotAllowedErrorConverter : ErrorConverter<AssetTypeNotAllowedValidationError>
+    {
+        protected override ErrorMessage Convert(AssetTypeNotAllowedValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new ErrorMessage("D59", $"AssetType for metering point {validationError.GsrnNumber} is not allowed.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeWrongValueErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/AssetTypeWrongValueErrorConverter.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
+{
+    public class AssetTypeWrongValueErrorConverter : ErrorConverter<AssetTypeWrongValueValidationError>
+    {
+        protected override ErrorMessage Convert(AssetTypeWrongValueValidationError validationError)
+        {
+            if (validationError == null) throw new ArgumentNullException(nameof(validationError));
+
+            return new ErrorMessage("D59", $"AssetType {validationError.AssetType} for metering point {validationError.GsrnNumber} has wrong value (outside domain)");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/ConverterMapperConfigurationBuilder.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/ConverterMapperConfigurationBuilder.cs
@@ -38,7 +38,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter
             }
         }
 
-        public ConverterMapperConfigurationBuilder<T> AddProperty<TProperty>(Expression<Func<T, string>> selector, Func<XmlElementInfo, TProperty> translatorFunc, params string[] xmlHierarchy)
+        public ConverterMapperConfigurationBuilder<T> AddProperty<TProperty>(Expression<Func<T, string?>> selector, Func<XmlElementInfo, TProperty> translatorFunc, params string[] xmlHierarchy)
         {
             return AddPropertyInternal(selector, CastFunc(translatorFunc), xmlHierarchy);
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/CreateMeteringPointXmlMappingConfiguration.cs
@@ -71,8 +71,6 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 "D01" => nameof(SettlementMethod.Flex),
                 "E02" => nameof(SettlementMethod.NonProfiled),
                 "E01" => nameof(SettlementMethod.Profiled),
-                // TODO: don't return empty string.
-                // TODO: Pass through original value instead.
                 _ => element.SourceValue,
             };
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Processing/Contracts/Contract.proto
@@ -55,7 +55,7 @@ message CreateMeteringPoint {
   string physicalStatusOfMeteringPoint = 18;
   string netSettlementGroup = 19;
   string connectionType = 20;
-  string assetType = 21;
+  google.protobuf.StringValue assetType = 21;
   string fromGrid = 22;
   string toGrid = 23;
   string productType = 24;

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/AssetTypeRuleTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/AssetTypeRuleTests.cs
@@ -1,0 +1,82 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Application;
+using Energinet.DataHub.MeteringPoints.Application.Validation.Rules;
+using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using FluentAssertions;
+using Xunit;
+using Xunit.Categories;
+
+namespace Energinet.DataHub.MeteringPoints.Tests.Validation
+{
+    [UnitTest]
+    public class AssetTypeRuleTests : RuleSetTest<CreateMeteringPoint, AssetTypeRule>
+    {
+        [Theory]
+        [InlineData(nameof(AssetType.CombustionEngineGas), nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One))]
+        [InlineData(nameof(AssetType.CombustionEngineGas), nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Six))]
+        [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero))]
+        [InlineData(null, nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Zero))]
+        public void ShouldValidate(string assetType, string meteringPointType, string netSettlementGroup)
+        {
+            var request = CreateRequest() with
+            {
+                NetSettlementGroup = netSettlementGroup,
+                AssetType = assetType,
+                TypeOfMeteringPoint = meteringPointType,
+            };
+
+            var errors = Validate(request);
+
+            errors.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(AssetTypeMandatoryValidationError))]
+        [InlineData(null, nameof(MeteringPointType.Production), nameof(NetSettlementGroup.Six), typeof(AssetTypeMandatoryValidationError))]
+        [InlineData("", nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Six), typeof(AssetTypeMandatoryValidationError))]
+        [InlineData(null, nameof(MeteringPointType.Consumption), nameof(NetSettlementGroup.Six), typeof(AssetTypeMandatoryValidationError))]
+
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.Analysis), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.ExchangeReactiveEnergy), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.InternalUse), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.Exchange), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.GridLossCorrection), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.ElectricalHeating), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+        [InlineData(nameof(AssetType.Boiler), nameof(MeteringPointType.NetConsumption), nameof(NetSettlementGroup.One), typeof(AssetTypeNotAllowedValidationError))]
+
+        [InlineData("WrongAssetTypeValue", nameof(MeteringPointType.Production), nameof(NetSettlementGroup.One), typeof(AssetTypeWrongValueValidationError))]
+        public void ShouldResultInError(string assetType, string meteringPointType, string netSettlementGroup, Type expectedError)
+        {
+            var request = CreateRequest() with
+            {
+                NetSettlementGroup = netSettlementGroup,
+                AssetType = assetType,
+                TypeOfMeteringPoint = meteringPointType,
+            };
+
+            var errors = Validate(request);
+
+            errors.Should().ContainSingle(error => error.GetType() == expectedError);
+        }
+
+        private static CreateMeteringPoint CreateRequest()
+        {
+            return new();
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Validation/RuleSetTest.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Validation/RuleSetTest.cs
@@ -14,29 +14,20 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using Energinet.DataHub.MeteringPoints.Application;
-using Energinet.DataHub.MeteringPoints.Application.Validation;
-using Energinet.DataHub.MeteringPoints.Application.Validation.Rules;
-using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
-using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
-using FluentAssertions;
 using FluentValidation;
-using Xunit;
-using Xunit.Categories;
 
 namespace Energinet.DataHub.MeteringPoints.Tests.Validation
 {
     public abstract class RuleSetTest<TRequest, TRuleSet>
         where TRuleSet : AbstractValidator<TRequest>, new()
     {
-        protected IReadOnlyCollection<ValidationError> Validate(TRequest request)
+        protected IEnumerable<ValidationError> Validate(TRequest request)
         {
             var validationResult = new RuleSet().Validate(request);
 
             return validationResult.Errors
-                .Select(error => (ValidationError)error.CustomState)
-                .ToList();
+                .Select(error => (ValidationError)error.CustomState);
         }
 
         private class RuleSet : AbstractValidator<TRequest>


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

- The AssetType has domain values D01 –D20 or D99

- For Production metering point (E18) the AssetType is mandatory. For a Consumption metering point (E17) in net settlement group not 0 the AssetType is mandatory, optional for other net settlement groups. AssetType is optional for TypeOfMP D01, D04 – D12, D17 and D18, else not allowed

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
