### PR TITLE
fix: using local db shouldn't use container

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -75,7 +75,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             _container = new Container();
             _container.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
 
-            var connectionString = databaseFixture.GetConnectionString.Value;
+            var connectionString = databaseFixture.GetConnectionString();
 
             var serviceCollection = new ServiceCollection();
 

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Tooling/DatabaseFixture.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Tooling/DatabaseFixture.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.Helpers;
 using Squadron;
 
@@ -20,43 +21,45 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling
 {
     public class DatabaseFixture : SqlServerResource
     {
-        private const string LocalConnectionStringName = "MeteringPoints_IntegrationTests_ConnectionString";
-        private const string UseLocalDatabaseSettingName = "MeteringPoints_use_local_database";
-
-        public DatabaseFixture()
-        {
-            GetConnectionString = new Lazy<string>(() =>
-            {
-                var connectionString = GetLocalOrContainerConnectionString();
-                var upgrader = UpgradeFactory.GetUpgradeEngine(connectionString, x => true, false);
-                var result = upgrader.PerformUpgrade();
-                if (result.Successful)
-                {
-                    return connectionString;
-                }
-                else
-                {
-                    throw new InvalidOperationException("Couldn't start test SQL server");
-                }
-            });
-        }
-
-        public Lazy<string> GetConnectionString { get; }
+        private const string LocalConnectionStringName = "IntegrationTests_ConnectionString";
 
         private static bool UseLocalDatabase =>
-            Environment.GetEnvironmentVariable(UseLocalDatabaseSettingName) is "true";
+            Environment.GetEnvironmentVariable(LocalConnectionStringName) != null;
 
         private static string LocalConnectionString =>
             Environment.GetEnvironmentVariable(LocalConnectionStringName)
             ?? throw new InvalidOperationException($"{LocalConnectionStringName} config not set");
 
-        private string GetLocalOrContainerConnectionString()
+        public override Task InitializeAsync()
+        {
+            // If we're using a local database, skip the squadron initialization.
+            return UseLocalDatabase
+                ? Task.CompletedTask
+                : base.InitializeAsync();
+        }
+
+        public string GetConnectionString()
+        {
+            var connectionString = CreateConnectionString();
+            UpdateDatabase(connectionString);
+            return connectionString;
+        }
+
+        private static void UpdateDatabase(string connectionString)
+        {
+            var upgrader = UpgradeFactory.GetUpgradeEngine(connectionString, x => true, false);
+            var result = upgrader.PerformUpgrade();
+            if (!result.Successful)
+            {
+                throw new InvalidOperationException("Couldn't start test SQL server");
+            }
+        }
+
+        private string CreateConnectionString()
         {
             return UseLocalDatabase
                 ? LocalConnectionString
-#pragma warning disable VSTHRD002 // Yeah, this is not ideal. Refactor to avoid instantiating this in the constructor.
-                : CreateDatabaseAsync().Result;
-#pragma warning restore VSTHRD002
+                : CreateConnectionString(UniqueNameGenerator.Create("db"));
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug where a container will be used regardless of whether or not you're running with a local database.

Use IntegrationTests_ConnectionString as local database name.