### PR TITLE
Add contains to reflection strategy

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CacheAllReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CacheAllReflectionStrategy.cs
@@ -49,17 +49,10 @@ namespace Energinet.DataHub.MeteringPoints.Benchmarks.ReflectionStrategies
         }
 
         internal override bool ContainsName<T>(string name)
-        {
-            var element = GetAll<T>()
-                .FirstOrDefault(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            return element is not null;
-        }
+            => GetAll<T>().Any(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
         internal override bool ContainsValue<T>(int value)
-        {
-            var element = GetAll<T>().FirstOrDefault(item => item.Id == value);
-            return element is not null;
-        }
+            => GetAll<T>().Any(item => item.Id == value);
 
         private IEnumerable<T> GetFieldsFrom<T>(int index)
         {

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CacheAllReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CacheAllReflectionStrategy.cs
@@ -48,6 +48,19 @@ namespace Energinet.DataHub.MeteringPoints.Benchmarks.ReflectionStrategies
             return matchingItem;
         }
 
+        internal override bool ContainsName<T>(string name)
+        {
+            var element = GetAll<T>()
+                .FirstOrDefault(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            return element is not null;
+        }
+
+        internal override bool ContainsValue<T>(int value)
+        {
+            var element = GetAll<T>().FirstOrDefault(item => item.Id == value);
+            return element is not null;
+        }
+
         private IEnumerable<T> GetFieldsFrom<T>(int index)
         {
             lock (_resizeLock)

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CheckOnInvocationReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CheckOnInvocationReflectionStrategy.cs
@@ -44,6 +44,19 @@ namespace Energinet.DataHub.MeteringPoints.Benchmarks.ReflectionStrategies
             return matchingItem;
         }
 
+        internal override bool ContainsName<T>(string name)
+        {
+            var matchingItem = GetAll<T>()
+                .FirstOrDefault(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            return matchingItem is not null;
+        }
+
+        internal override bool ContainsValue<T>(int value)
+        {
+            var matchingItem = GetAll<T>().FirstOrDefault(item => item.Id == value);
+            return matchingItem is not null;
+        }
+
         private T Parse<T, TValue>(TValue value, string description, Func<T, bool> predicate)
             where T : EnumerationType
         {

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CheckOnInvocationReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategies/CheckOnInvocationReflectionStrategy.cs
@@ -45,17 +45,10 @@ namespace Energinet.DataHub.MeteringPoints.Benchmarks.ReflectionStrategies
         }
 
         internal override bool ContainsName<T>(string name)
-        {
-            var matchingItem = GetAll<T>()
-                .FirstOrDefault(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-            return matchingItem is not null;
-        }
+            => GetAll<T>().Any(item => item.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
 
         internal override bool ContainsValue<T>(int value)
-        {
-            var matchingItem = GetAll<T>().FirstOrDefault(item => item.Id == value);
-            return matchingItem is not null;
-        }
+            => GetAll<T>().Any(item => item.Id == value);
 
         private T Parse<T, TValue>(TValue value, string description, Func<T, bool> predicate)
             where T : EnumerationType

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategyBenchmarks.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/ReflectionStrategyBenchmarks.cs
@@ -71,5 +71,29 @@ namespace Energinet.DataHub.MeteringPoints.Benchmarks
         [Benchmark(Description = nameof(DictionaryCacheReflectionStrategy))]
         [BenchmarkCategory("FromValue")]
         public void ExpressionCache_FromValue() => _dictionaryCache.FromValue<DocumentTypes>(5);
+
+        [Benchmark(Baseline = true, Description = nameof(CheckOnInvocationReflectionStrategy))]
+        [BenchmarkCategory("ContainsValue")]
+        public void CheckOnInvocation_ContainsValue() => _checkOnInvocation.ContainsValue<DocumentTypes>(5);
+
+        [Benchmark(Description = nameof(CacheAllReflectionStrategy))]
+        [BenchmarkCategory("ContainsValue")]
+        public void CacheAll_ContainsValue() => _cacheAll.ContainsValue<DocumentTypes>(5);
+
+        [Benchmark(Description = nameof(DictionaryCacheReflectionStrategy))]
+        [BenchmarkCategory("ContainsValue")]
+        public void ExpressionCache_ContainsValue() => _dictionaryCache.ContainsValue<DocumentTypes>(5);
+
+        [Benchmark(Baseline = true, Description = nameof(CheckOnInvocationReflectionStrategy))]
+        [BenchmarkCategory("ContainsName")]
+        public void CheckOnInvocation_ContainsName() => _checkOnInvocation.ContainsName<DocumentTypes>("Lens");
+
+        [Benchmark(Description = nameof(CacheAllReflectionStrategy))]
+        [BenchmarkCategory("ContainsName")]
+        public void CacheAll_ContainsName() => _cacheAll.ContainsName<DocumentTypes>("Lens");
+
+        [Benchmark(Description = nameof(DictionaryCacheReflectionStrategy))]
+        [BenchmarkCategory("ContainsName")]
+        public void ExpressionCache_ContainsName() => _dictionaryCache.ContainsName<DocumentTypes>("Lens");
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/DictionaryCacheReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/DictionaryCacheReflectionStrategy.cs
@@ -61,6 +61,16 @@ namespace Energinet.DataHub.MeteringPoints.Domain.SeedWork.Internals
             return (T)GetFromCache<T>().FromValue(value);
         }
 
+        internal override bool ContainsName<T>(string name)
+        {
+            return GetFromCache<T>().ContainsName(name);
+        }
+
+        internal override bool ContainsValue<T>(int value)
+        {
+            return GetFromCache<T>().ContainsValue(value);
+        }
+
         private EnumerationReflection GetFromCache<T>()
             where T : EnumerationType
         {

--- a/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/EnumerationReflection.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/EnumerationReflection.cs
@@ -52,6 +52,13 @@ namespace Energinet.DataHub.MeteringPoints.Domain.SeedWork.Internals
             throw new InvalidOperationException();
         }
 
+        public bool ContainsName(string name)
+        {
+            return _nameLookup.ContainsKey(name.ToUpperInvariant());
+        }
+
+        public bool ContainsValue(int value) => _valueLookup.ContainsKey(value);
+
         internal static EnumerationReflection Create<T>()
             where T : EnumerationType
         {

--- a/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/ReflectionStrategy.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/SeedWork/Internals/ReflectionStrategy.cs
@@ -26,5 +26,11 @@ namespace Energinet.DataHub.MeteringPoints.Domain.SeedWork.Internals
 
         internal abstract T FromValue<T>(int value)
             where T : EnumerationType;
+
+        internal abstract bool ContainsName<T>(string name)
+            where T : EnumerationType;
+
+        internal abstract bool ContainsValue<T>(int value)
+            where T : EnumerationType;
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/EnumerationTypeTest/ReflectionStrategyTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/EnumerationTypeTest/ReflectionStrategyTests.cs
@@ -14,9 +14,11 @@
 
 using System;
 using System.Linq;
+using System.Reflection.Metadata;
 using Energinet.DataHub.MeteringPoints.Benchmarks.ReflectionStrategies;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork.Internals;
 using Energinet.DataHub.MeteringPoints.Tests.Assets;
+using Microsoft.Diagnostics.Tracing.Analysis.JIT;
 using Xunit;
 using Xunit.Categories;
 
@@ -72,6 +74,31 @@ namespace Energinet.DataHub.MeteringPoints.Tests.EnumerationTypeTest
             Assert.NotEmpty(fields);
             Assert.Equal(5, fields.Length);
             Assert.Contains(DocumentTypes.Lens, fields);
+        }
+
+        [Theory]
+        [InlineData(nameof(DocumentTypes.Lens), true)]
+        [InlineData("name-not-known", false)]
+        public void Given_a_document_type_When_contains_name_is_invoked_Then_it_match_the_result(string documentType, bool expected)
+        {
+            var sut = CreateStrategy();
+
+            var result = sut.ContainsName<DocumentTypes>(documentType);
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(5, true)]
+        [InlineData(-1, false)]
+        public void Given_a_document_type_When_contains_value_is_invoked_Then_it_match_the_result(
+            int value,
+            bool expected)
+        {
+            var sut = CreateStrategy();
+            var result = sut.ContainsValue<DocumentTypes>(value);
+
+            Assert.Equal(expected, result);
         }
 
         protected abstract ReflectionStrategy CreateStrategy();


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

Add two new methods to ReflectionStrategy.
 - ContainsName
 - ContainsValue

They can be used to test if name or value is present within an EnumerationType

## Benchmark

|                              Method |    Categories |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------ |-------------- |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
| CheckOnInvocationReflectionStrategy |        GetAll | 146.81 ns | 1.683 ns | 1.492 ns |  1.00 |    0.00 | 0.0534 |     - |     - |     168 B |
|          CacheAllReflectionStrategy |        GetAll |  12.94 ns | 0.172 ns | 0.161 ns |  0.09 |    0.00 |      - |     - |     - |         - |
|   DictionaryCacheReflectionStrategy |        GetAll |  29.42 ns | 0.567 ns | 0.530 ns |  0.20 |    0.00 | 0.0179 |     - |     - |      56 B |
|                                     |               |           |          |          |       |         |        |       |       |           |
| CheckOnInvocationReflectionStrategy |      FromName | 499.65 ns | 9.262 ns | 8.664 ns |  1.00 |    0.00 | 0.0811 |     - |     - |     256 B |
|          CacheAllReflectionStrategy |      FromName | 353.99 ns | 7.001 ns | 8.854 ns |  0.71 |    0.02 | 0.0610 |     - |     - |     192 B |
|   DictionaryCacheReflectionStrategy |      FromName |  47.35 ns | 0.714 ns | 0.596 ns |  0.09 |    0.00 | 0.0102 |     - |     - |      32 B |
|                                     |               |           |          |          |       |         |        |       |       |           |
| CheckOnInvocationReflectionStrategy |     FromValue | 459.47 ns | 6.082 ns | 5.689 ns |  1.00 |    0.00 | 0.0815 |     - |     - |     256 B |
|          CacheAllReflectionStrategy |     FromValue | 334.35 ns | 6.435 ns | 6.608 ns |  0.73 |    0.02 | 0.0610 |     - |     - |     192 B |
|   DictionaryCacheReflectionStrategy |     FromValue |  21.73 ns | 0.260 ns | 0.230 ns |  0.05 |    0.00 |      - |     - |     - |         - |
|                                     |               |           |          |          |       |         |        |       |       |           |
| CheckOnInvocationReflectionStrategy | ContainsValue | 461.05 ns | 6.836 ns | 6.394 ns |  1.00 |    0.00 | 0.0815 |     - |     - |     256 B |
|          CacheAllReflectionStrategy | ContainsValue | 334.44 ns | 6.071 ns | 7.894 ns |  0.73 |    0.02 | 0.0610 |     - |     - |     192 B |
|   DictionaryCacheReflectionStrategy | ContainsValue |  17.59 ns | 0.189 ns | 0.158 ns |  0.04 |    0.00 |      - |     - |     - |         - |
|                                     |               |           |          |          |       |         |        |       |       |           |
| CheckOnInvocationReflectionStrategy |  ContainsName | 489.54 ns | 5.734 ns | 4.788 ns |  1.00 |    0.00 | 0.0811 |     - |     - |     256 B |
|          CacheAllReflectionStrategy |  ContainsName | 361.85 ns | 5.985 ns | 6.404 ns |  0.74 |    0.02 | 0.0610 |     - |     - |     192 B |
|   DictionaryCacheReflectionStrategy |  ContainsName |  40.91 ns | 0.575 ns | 0.538 ns |  0.08 |    0.00 | 0.0102 |     - |     - |      32 B |


## References

Can be used in PR #274
