### PR TITLE
Sender connection string instead of listener in internal command dispatcher

### DIFF
--- a/build/infrastructure/main/azfun-internalcommanddispatcher.tf
+++ b/build/infrastructure/main/azfun-internalcommanddispatcher.tf
@@ -31,7 +31,7 @@ module "azfun_internalcommanddispatcher" {
     # Endregion: Default Values
     DB_CONNECTION_STRING                  = local.METERING_POINT_CONNECTION_STRING
     PROCESSING_QUEUE_NAME                 = module.sbq_meteringpoint.name
-    PROCESSING_QUEUE_CONNECTION_STRING    = module.sbnar_meteringpoint_listener.primary_connection_string
+    PROCESSING_QUEUE_CONNECTION_STRING    = module.sbnar_meteringpoint_sender.primary_connection_string
     DISPATCH_TRIGGER_TIMER                = "*/10 * * * * *"
   }
   dependencies                              = [


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
