### PR TITLE
Send all outgoing notifications to MessageHub trough Outbox

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
@@ -25,8 +25,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.2.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.2.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.3.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.3.0" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
@@ -112,13 +112,15 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub
             container.Register<IRequestHandler<BundleRequest<RejectMessage>, string>, RejectMessageBundleHandler>(Lifestyle.Scoped);
 
             var messageHubStorageConnectionString = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONNECTION_STRING") ?? throw new InvalidOperationException("MessageHub storage connection string not found.");
+            var messageHubStorageContainerName = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONTAINER_NAME") ?? throw new InvalidOperationException("MessageHub storage container name not found.");
             var messageHubServiceBusConnectionString = Environment.GetEnvironmentVariable("MESSAGEHUB_QUEUE_CONNECTION_STRING") ?? throw new InvalidOperationException("MessageHub queue connection string not found.");
 
-            container.AddPostOfficeCommunication(messageHubServiceBusConnectionString, new MessageHubConfig("sbq-dataavailable", "sbq-meteringpoints-reply"), messageHubStorageConnectionString, new StorageConfig("postoffice-blobstorage"));
+            container.AddMessageHubCommunication(messageHubServiceBusConnectionString, new MessageHubConfig("sbq-dataavailable", "sbq-meteringpoints-reply"), messageHubStorageConnectionString, new StorageConfig(messageHubStorageContainerName));
 
             container.Register<ILocalMessageHubClient, LocalMessageHubClient>(Lifestyle.Scoped);
             container.Register<IMessageHubMessageRepository, MessageHubMessageRepository>(Lifestyle.Scoped);
-            container.Register<INotificationHandler, MeteringPointNotificationHandler>(Lifestyle.Scoped);
+            container.Register<IOutboxDispatcher<DataBundleResponse>, DataBundleResponseOutboxDispatcher>();
+            container.Register<IOutboxDispatcher<MessageHubMessage>, MeteringPointMessageDequeuedIntegrationEventOutboxDispatcher>(Lifestyle.Scoped);
             container.Register<IOutboxMessageFactory, OutboxMessageFactory>(Lifestyle.Scoped);
             container.Register<IOutbox, OutboxProvider>(Lifestyle.Scoped);
             container.Register<IBundleCreator, BundleCreator>(Lifestyle.Scoped);

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/ActorMessages/MessageHubDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/ActorMessages/MessageHubDispatcher.cs
@@ -30,13 +30,13 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.ActorMessages
             _localMessageHubDataAvailableClient = localMessageHubDataAvailableClient;
         }
 
-        public async Task<Unit> Handle(MessageHubEnvelope request, CancellationToken cancellationToken)
+        public Task<Unit> Handle(MessageHubEnvelope request, CancellationToken cancellationToken)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
 
-            await _localMessageHubDataAvailableClient.DataAvailableAsync(request).ConfigureAwait(false);
+            _localMessageHubDataAvailableClient.DataAvailable(request);
 
-            return Unit.Value;
+            return Task.FromResult(Unit.Value);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Common/OutboxOrchestrator.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Common/OutboxOrchestrator.cs
@@ -12,13 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
-using Microsoft.Extensions.DependencyInjection;
-using SimpleInjector;
-using SimpleInjector.Lifestyles;
 
 namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.Common
 {

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -24,8 +24,8 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.2.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.2.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.3.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.3.0" />
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/IntegrationEventDispatchers/MeteringPointConnectedDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/IntegrationEventDispatchers/MeteringPointConnectedDispatcher.cs
@@ -17,7 +17,6 @@ using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.Common;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Connect;
-using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf;
 
 namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.IntegrationEventDispatchers

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/MessageHub/DataAvailableNotificationDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/MessageHub/DataAvailableNotificationDispatcher.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MessageHub.Client.DataAvailable;
+using Energinet.DataHub.MessageHub.Client.Model;
+using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
+using MediatR;
+
+namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.MessageHub
+{
+    public class DataAvailableNotificationDispatcher : IRequestHandler<DataAvailableNotification>
+    {
+        private readonly IDataAvailableNotificationSender _dataAvailableNotificationSender;
+
+        public DataAvailableNotificationDispatcher(IDataAvailableNotificationSender dataAvailableNotificationSender)
+        {
+            _dataAvailableNotificationSender = dataAvailableNotificationSender;
+        }
+
+        public async Task<Unit> Handle(DataAvailableNotification request, CancellationToken cancellationToken)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+
+            await _dataAvailableNotificationSender.SendAsync(new DataAvailableNotificationDto(request.Uuid, request.Recipient, request.MessageType, request.Origin, request.SupportsBundling, request.RelativeWeight)).ConfigureAwait(false);
+
+            return Unit.Value;
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/MessageHub/DataBundleResponseDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/MessageHub/DataBundleResponseDispatcher.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MessageHub.Client.Extensions;
+using Energinet.DataHub.MessageHub.Client.Peek;
+using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
+using MediatR;
+
+namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.MessageHub
+{
+    public class DataBundleResponseDispatcher : IRequestHandler<DataBundleResponse>
+    {
+        private readonly IDataBundleResponseSender _dataBundleResponseSender;
+
+        public DataBundleResponseDispatcher(IDataBundleResponseSender dataBundleResponseSender)
+        {
+            _dataBundleResponseSender = dataBundleResponseSender;
+        }
+
+        public async Task<Unit> Handle(DataBundleResponse request, CancellationToken cancellationToken)
+        {
+            if (request == null) throw new ArgumentNullException(nameof(request));
+
+            await _dataBundleResponseSender.SendAsync(request.DataBundleRequestDto.CreateResponse(request.Path), request.DataBundleRequestDto, request.SessionId).ConfigureAwait(false);
+
+            return Unit.Value;
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
@@ -133,12 +133,18 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox
 
             container.Register<IMessageHubMessageRepository, MessageHubMessageRepository>(Lifestyle.Scoped);
             container.Register<ILocalMessageHubDataAvailableClient, LocalMessageHubDataAvailableClient>(Lifestyle.Scoped);
+
+            container.Register<IOutboxDispatcher<DataAvailableNotification>, DataAvailableNotificationOutboxDispatcher>();
+            container.Register<IOutboxMessageFactory, OutboxMessageFactory>(Lifestyle.Scoped);
+            container.Register<IOutbox, OutboxProvider>(Lifestyle.Scoped);
+
             container.Register<MessageHubMessageFactory>(Lifestyle.Scoped);
 
             var messageHubStorageConnectionString = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONNECTION_STRING") ?? throw new InvalidOperationException("MessageHub storage connection string not found.");
+            var messageHubStorageContainerName = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONTAINER_NAME") ?? throw new InvalidOperationException("MessageHub storage container name not found.");
             var messageHubServiceBusConnectionString = Environment.GetEnvironmentVariable("MESSAGEHUB_QUEUE_CONNECTION_STRING") ?? throw new InvalidOperationException("MessageHub queue connection string not found.");
 
-            container.AddPostOfficeCommunication(messageHubServiceBusConnectionString, new MessageHubConfig("sbq-dataavailable", "sbq-meteringpoints-reply"), messageHubStorageConnectionString, new StorageConfig("postoffice-blobstorage"));
+            container.AddMessageHubCommunication(messageHubServiceBusConnectionString, new MessageHubConfig("sbq-dataavailable", "sbq-meteringpoints-reply"), messageHubStorageConnectionString, new StorageConfig(messageHubStorageContainerName));
 
             // Setup pipeline behaviors
             container.BuildMediator(

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -23,7 +23,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.3.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.2.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.3.0" />
     <PackageReference Include="Google.Protobuf" Version="3.18.0" />
     <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/Helpers/OutboxTypeFactory.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/Helpers/OutboxTypeFactory.cs
@@ -20,6 +20,7 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEve
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Consumption;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.MessageDequeued;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Production;
+using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.Integration.Helpers
 {
@@ -33,6 +34,8 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Integration.Helpers
             { typeof(MeteringPointConnectedIntegrationEvent).FullName!, typeof(MeteringPointConnectedIntegrationEvent) },
             { typeof(MessageHubEnvelope).FullName!, typeof(MessageHubEnvelope) },
             { typeof(MeteringPointMessageDequeuedIntegrationEvent).FullName!, typeof(MeteringPointMessageDequeuedIntegrationEvent) },
+            { typeof(DataBundleResponse).FullName!, typeof(DataBundleResponse) },
+            { typeof(DataAvailableNotification).FullName!, typeof(DataAvailableNotification) },
         };
 
         public static Type GetType(string type)

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/DataAvailableNotification.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/DataAvailableNotification.cs
@@ -12,25 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
-using Energinet.DataHub.MessageHub.Client.DataAvailable;
+using System;
 using Energinet.DataHub.MessageHub.Client.Model;
+using MediatR;
 
-namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub
 {
-    public class DataAvailableNotificationSenderMock : IDataAvailableNotificationSender
-    {
-        private bool _isSent;
-
-        public Task SendAsync(DataAvailableNotificationDto dataAvailableNotificationDto)
-        {
-            _isSent = true;
-            return Task.CompletedTask;
-        }
-
-        public bool IsSent()
-        {
-            return _isSent;
-        }
-    }
+    public record DataAvailableNotification(Guid Uuid, GlobalLocationNumberDto Recipient, MessageTypeDto MessageType, DomainOrigin Origin, bool SupportsBundling, int RelativeWeight) : IRequest;
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/DataBundleResponse.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/DataBundleResponse.cs
@@ -12,20 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
-using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
+using System;
+using Energinet.DataHub.MessageHub.Client.Model;
+using MediatR;
 
-namespace Energinet.DataHub.MeteringPoints.Messaging
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub
 {
-    /// <summary>
-    /// Local Post Office
-    /// </summary>
-    public interface ILocalMessageHubDataAvailableClient
-    {
-        /// <summary>
-        /// Dispatch message to Local Post Office
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        void DataAvailable(MessageHubEnvelope messageHub);
-    }
+    public record DataBundleResponse(DataBundleRequestDto DataBundleRequestDto, Uri Path, string SessionId) : IRequest;
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/IOutboxDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/LocalMessageHub/IOutboxDispatcher.cs
@@ -12,20 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
-using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
-
-namespace Energinet.DataHub.MeteringPoints.Messaging
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub
 {
     /// <summary>
-    /// Local Post Office
+    /// Handling of outgoing messages
     /// </summary>
-    public interface ILocalMessageHubDataAvailableClient
+    public interface IOutboxDispatcher<in T>
     {
         /// <summary>
-        /// Dispatch message to Local Post Office
+        /// Handle a single outgoing message
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        void DataAvailable(MessageHubEnvelope messageHub);
+        /// <param name="message"></param>
+        public void Dispatch(T message);
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Outbox/OutboxMessageCategory.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Outbox/OutboxMessageCategory.cs
@@ -18,8 +18,9 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Outbox
 {
     public class OutboxMessageCategory : EnumerationType
     {
-        public static readonly OutboxMessageCategory IntegrationEvent = new OutboxMessageCategory(0, nameof(IntegrationEvent));
-        public static readonly OutboxMessageCategory ActorMessage = new OutboxMessageCategory(1, nameof(ActorMessage));
+        public static readonly OutboxMessageCategory IntegrationEvent = new(0, nameof(IntegrationEvent));
+        public static readonly OutboxMessageCategory ActorMessage = new(1, nameof(ActorMessage));
+        public static readonly OutboxMessageCategory MessageHub = new(2, nameof(MessageHub));
 
         public OutboxMessageCategory(int id, string name)
             : base(id, name)

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/DataAvailableNotificationOutboxDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/DataAvailableNotificationOutboxDispatcher.cs
@@ -13,30 +13,27 @@
 // limitations under the License.
 
 using System;
-using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.MessageDequeued;
 using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 
 namespace Energinet.DataHub.MeteringPoints.Messaging
 {
-    public class MeteringPointMessageDequeuedIntegrationEventOutboxDispatcher : IOutboxDispatcher<MessageHubMessage>
+    public class DataAvailableNotificationOutboxDispatcher : IOutboxDispatcher<DataAvailableNotification>
     {
         private readonly IOutboxMessageFactory _outboxMessageFactory;
         private readonly IOutbox _outbox;
 
-        public MeteringPointMessageDequeuedIntegrationEventOutboxDispatcher(IOutboxMessageFactory outboxMessageFactory, IOutbox outbox)
+        public DataAvailableNotificationOutboxDispatcher(IOutboxMessageFactory outboxMessageFactory, IOutbox outbox)
         {
             _outboxMessageFactory = outboxMessageFactory;
             _outbox = outbox;
         }
 
-        public void Dispatch(MessageHubMessage message)
+        public void Dispatch(DataAvailableNotification message)
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            var integrationEvent = new MeteringPointMessageDequeuedIntegrationEvent(message.Correlation);
-
-            var outboxMessage = _outboxMessageFactory.CreateFrom(integrationEvent, OutboxMessageCategory.IntegrationEvent);
+            var outboxMessage = _outboxMessageFactory.CreateFrom(message, OutboxMessageCategory.MessageHub);
             _outbox.Add(outboxMessage);
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/DataBundleResponseOutboxDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/DataBundleResponseOutboxDispatcher.cs
@@ -13,30 +13,27 @@
 // limitations under the License.
 
 using System;
-using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.MessageDequeued;
 using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 
 namespace Energinet.DataHub.MeteringPoints.Messaging
 {
-    public class MeteringPointMessageDequeuedIntegrationEventOutboxDispatcher : IOutboxDispatcher<MessageHubMessage>
+    public class DataBundleResponseOutboxDispatcher : IOutboxDispatcher<DataBundleResponse>
     {
         private readonly IOutboxMessageFactory _outboxMessageFactory;
         private readonly IOutbox _outbox;
 
-        public MeteringPointMessageDequeuedIntegrationEventOutboxDispatcher(IOutboxMessageFactory outboxMessageFactory, IOutbox outbox)
+        public DataBundleResponseOutboxDispatcher(IOutboxMessageFactory outboxMessageFactory, IOutbox outbox)
         {
             _outboxMessageFactory = outboxMessageFactory;
             _outbox = outbox;
         }
 
-        public void Dispatch(MessageHubMessage message)
+        public void Dispatch(DataBundleResponse message)
         {
             if (message is null) throw new ArgumentNullException(nameof(message));
 
-            var integrationEvent = new MeteringPointMessageDequeuedIntegrationEvent(message.Correlation);
-
-            var outboxMessage = _outboxMessageFactory.CreateFrom(integrationEvent, OutboxMessageCategory.IntegrationEvent);
+            var outboxMessage = _outboxMessageFactory.CreateFrom(message, OutboxMessageCategory.MessageHub);
             _outbox.Add(outboxMessage);
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
@@ -21,7 +21,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.2.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.3.0" />
     <PackageReference Include="MediatR" Version="9.0.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubDataAvailableClient.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubDataAvailableClient.cs
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Threading.Tasks;
-using Energinet.DataHub.MessageHub.Client.DataAvailable;
 using Energinet.DataHub.MessageHub.Client.Model;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
@@ -23,21 +21,21 @@ namespace Energinet.DataHub.MeteringPoints.Messaging
 {
     public class LocalMessageHubDataAvailableClient : ILocalMessageHubDataAvailableClient
     {
-        private readonly IDataAvailableNotificationSender _dataAvailableNotificationSender;
+        private readonly IOutboxDispatcher<DataAvailableNotification> _dataAvailableOutboxDispatcher;
         private readonly MessageHubMessageFactory _messageHubMessageFactory;
         private readonly IMessageHubMessageRepository _messageHubMessageRepository;
 
         public LocalMessageHubDataAvailableClient(
             IMessageHubMessageRepository messageHubMessageRepository,
-            IDataAvailableNotificationSender dataAvailableNotificationSender,
+            IOutboxDispatcher<DataAvailableNotification> dataAvailableOutboxDispatcher,
             MessageHubMessageFactory messageHubMessageFactory)
         {
             _messageHubMessageRepository = messageHubMessageRepository;
-            _dataAvailableNotificationSender = dataAvailableNotificationSender;
+            _dataAvailableOutboxDispatcher = dataAvailableOutboxDispatcher;
             _messageHubMessageFactory = messageHubMessageFactory;
         }
 
-        public async Task DataAvailableAsync(MessageHubEnvelope messageHub)
+        public void DataAvailable(MessageHubEnvelope messageHub)
         {
             if (messageHub is null)
             {
@@ -47,8 +45,7 @@ namespace Energinet.DataHub.MeteringPoints.Messaging
             var messageMetadata = _messageHubMessageFactory.Create(messageHub.Correlation, messageHub.Content, messageHub.MessageType, messageHub.Recipient);
             _messageHubMessageRepository.AddMessageMetadata(messageMetadata);
 
-            // TODO - add notification to Outbox instead of sending immediately
-            await _dataAvailableNotificationSender.SendAsync(new DataAvailableNotificationDto(messageMetadata.Id, new GlobalLocationNumberDto(messageHub.Recipient), new MessageTypeDto(messageHub.MessageType.Name), DomainOrigin.MeteringPoints, true, 1)).ConfigureAwait(false);
+            _dataAvailableOutboxDispatcher.Dispatch(new DataAvailableNotification(messageMetadata.Id, new GlobalLocationNumberDto(messageHub.Recipient), new MessageTypeDto(messageHub.MessageType.Name), DomainOrigin.MeteringPoints, true, 1));
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/AzureFunctionHostConfigurationTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/AzureFunctionHostConfigurationTests.cs
@@ -75,6 +75,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests
             Environment.SetEnvironmentVariable("METERING_POINT_CONNECTED_TOPIC", SomeString);
             Environment.SetEnvironmentVariable("MESSAGEHUB_QUEUE_CONNECTION_STRING", SomeString);
             Environment.SetEnvironmentVariable("MESSAGEHUB_STORAGE_CONNECTION_STRING", SomeString);
+            Environment.SetEnvironmentVariable("MESSAGEHUB_STORAGE_CONTAINER_NAME", SomeString);
             var program = new EntryPoints.Outbox.Program();
 
             program.ConfigureApplication();
@@ -90,6 +91,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests
             Environment.SetEnvironmentVariable("METERINGPOINT_QUEUE_TOPIC_NAME", SomeString);
             Environment.SetEnvironmentVariable("MESSAGEHUB_QUEUE_CONNECTION_STRING", SomeString);
             Environment.SetEnvironmentVariable("MESSAGEHUB_STORAGE_CONNECTION_STRING", SomeString);
+            Environment.SetEnvironmentVariable("MESSAGEHUB_STORAGE_CONTAINER_NAME", SomeString);
             Environment.SetEnvironmentVariable("CONSUMPTION_METERING_POINT_CREATED_TOPIC", SomeString);
             Environment.SetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY", SomeString);
             var program = new EntryPoints.LocalMessageHub.Program();

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
@@ -60,4 +60,9 @@ limitations under the License.
     <EmbeddedResource Include="EDI\CreateMeteringPoint\CreateMeteringPointCimXml.xml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="LocalMessageHub\Mocks\DataAvailableNotificationSenderMock.cs" />
+    <Compile Remove="LocalMessageHub\Mocks\DataBundleResponseSenderMock.cs" />
+  </ItemGroup>
+
 </Project>

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/DataAvailableNotificationOutboxDispatcherMock.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/DataAvailableNotificationOutboxDispatcherMock.cs
@@ -12,25 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Threading.Tasks;
-using Energinet.DataHub.MessageHub.Client.Model;
-using Energinet.DataHub.MessageHub.Client.Peek;
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 
 namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks
 {
-    public class DataBundleResponseSenderMock : IDataBundleResponseSender
+    public class DataAvailableNotificationOutboxDispatcherMock : IOutboxDispatcher<DataAvailableNotification>
     {
-        private bool _isSent;
+        private readonly List<DataAvailableNotification> _messages = new();
 
-        public bool IsSent()
+        public void Dispatch(DataAvailableNotification message)
         {
-            return _isSent;
+            _messages.Add(message);
         }
 
-        public Task SendAsync(DataBundleResponseDto dataBundleResponseDto, DataBundleRequestDto requestDto, string sessionId)
+        public bool IsDispatched()
         {
-            _isSent = true;
-            return Task.CompletedTask;
+            return _messages.Any();
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/DataBundleResponseOutboxDispatcherMock.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/DataBundleResponseOutboxDispatcherMock.cs
@@ -12,17 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub
+using System.Collections.Generic;
+using System.Linq;
+using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
+
+namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks
 {
-    /// <summary>
-    /// Handling of outgoing notifications
-    /// </summary>
-    public interface INotificationHandler
+    public class DataBundleResponseOutboxDispatcherMock : IOutboxDispatcher<DataBundleResponse>
     {
-        /// <summary>
-        /// Handle a single outgoing notification
-        /// </summary>
-        /// <param name="messageHubMessage"></param>
-        public void Handle(MessageHubMessage messageHubMessage);
+        private readonly List<DataBundleResponse> _messages = new();
+
+        public void Dispatch(DataBundleResponse message)
+        {
+            _messages.Add(message);
+        }
+
+        public bool IsDispatched()
+        {
+            return _messages.Any();
+        }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/MeteringPointMessageDequeuedIntegrationEventOutboxDispatcherMock.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/Mocks/MeteringPointMessageDequeuedIntegrationEventOutboxDispatcherMock.cs
@@ -18,7 +18,7 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 
 namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks
 {
-    public class MeteringPointIntegrationEventHandlerMock : INotificationHandler
+    public class MeteringPointMessageDequeuedIntegrationEventOutboxDispatcherMock : IOutboxDispatcher<MessageHubMessage>
     {
         private readonly List<MessageHubMessage> _messages = new();
 
@@ -27,9 +27,9 @@ namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks
             return _messages.Any(x => x.Correlation == correlation);
         }
 
-        public void Handle(MessageHubMessage messageHubMessage)
+        public void Dispatch(MessageHubMessage message)
         {
-            _messages.Add(messageHubMessage);
+            _messages.Add(message);
         }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

All outgoing notification to MessageHub are now send through Outbox. This way we are sure that we will never send notifications before transactions in LocalMessageHub are committed.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
