### PR TITLE
fix publish-release-action to be compatible with 1.13.0

### DIFF
--- a/.github/actions/publish-release-contents/action.yml
+++ b/.github/actions/publish-release-contents/action.yml
@@ -15,7 +15,7 @@ name: 'Publish release content'
 inputs:
   RELEASE_FOLDER_PATH:
     required: true
-  LOCAL_REPO_FOLDER_PATH:
+  REPO_FOLDER_PATH:
     required: true
 
 runs:
@@ -25,7 +25,7 @@ runs:
       shell: bash
       run: |
         mkdir ${{ inputs.RELEASE_FOLDER_PATH }}
-        cp -fR ${{ inputs.LOCAL_REPO_FOLDER_PATH }}/build/infrastructure ${{ inputs.RELEASE_FOLDER_PATH }} 2>/dev/null || :
+        cp -fR ${{ inputs.REPO_FOLDER_PATH }}/build/infrastructure ${{ inputs.RELEASE_FOLDER_PATH }} 2>/dev/null || :
 
     - name: Publish Ingestion to release folder
       uses: actions/download-artifact@v2


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
