### PR TITLE
updated creation of def links succesfull scenario with a better message

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
@@ -52,6 +52,14 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing.Functions
             await Task.CompletedTask.ConfigureAwait(false);
         }
 
+        private static string CreateSuccessMessage(DefaultChargeLinksCreatedSuccessfullyDto createDefaultChargeLinksSucceeded)
+        {
+            const string message = "Add default Charge Link request was successful.";
+            const string noChargeLinksWereCreated = " No charge links were created";
+
+            return createDefaultChargeLinksSucceeded.DidCreateChargeLinks ? message : $"{message}{noChargeLinksWereCreated}";
+        }
+
         private async Task HandleFailureAsync(DefaultChargeLinksCreationFailedStatusDto createDefaultChargeLinksFailed)
         {
             // TODO: Implement error handling
@@ -61,8 +69,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing.Functions
 
         private async Task HandleSuccessAsync(DefaultChargeLinksCreatedSuccessfullyDto createDefaultChargeLinksSucceeded)
         {
-            var message = $"Add default Charge Link request was successful.";
-            _logger.LogInformation(createDefaultChargeLinksSucceeded.DidCreateChargeLinks ? message : $"{message} No charge links were created");
+            _logger.LogInformation(CreateSuccessMessage(createDefaultChargeLinksSucceeded));
             CreateDefaultChargeLinksSucceeded notification = new(createDefaultChargeLinksSucceeded.MeteringPointId, createDefaultChargeLinksSucceeded.DidCreateChargeLinks, _correlationContext.Id);
             await _mediator.Publish(notification).ConfigureAwait(false);
             await Task.CompletedTask.ConfigureAwait(false);

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
@@ -61,7 +61,8 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing.Functions
 
         private async Task HandleSuccessAsync(DefaultChargeLinksCreatedSuccessfullyDto createDefaultChargeLinksSucceeded)
         {
-            _logger.LogInformation($"Add default Charge Link request was successful.");
+            var message = $"Add default Charge Link request was successful.";
+            _logger.LogInformation(createDefaultChargeLinksSucceeded.DidCreateChargeLinks ? message : $"{message} No charge links were created");
             CreateDefaultChargeLinksSucceeded notification = new(createDefaultChargeLinksSucceeded.MeteringPointId, createDefaultChargeLinksSucceeded.DidCreateChargeLinks, _correlationContext.Id);
             await _mediator.Publish(notification).ConfigureAwait(false);
             await Task.CompletedTask.ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

After having tested the creation of default charge links, I would like for small QOL feature. 

This PR will add:
- update to the message being logged when `ChargesResponseReceiver` handles a successful message.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
