### PR TITLE
Add hack for setting energy supplier details

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/SetEnergySupplierHACK.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/SetEnergySupplierHACK.cs
@@ -1,0 +1,48 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MeteringPoints.Application.Common.Commands;
+using Energinet.DataHub.MeteringPoints.Application.Connect;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+using MediatR;
+using MeteringPointCreated = Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.Events.MeteringPointCreated;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Create
+{
+    // TODO: This is a hack used during the test period and should be removed as soon as the business processes from Market roles are included
+    public class SetEnergySupplierHACK : INotificationHandler<MeteringPointCreated>
+    {
+        private readonly ICommandScheduler _commandScheduler;
+
+        public SetEnergySupplierHACK(ICommandScheduler commandScheduler)
+        {
+            _commandScheduler = commandScheduler ?? throw new ArgumentNullException(nameof(commandScheduler));
+        }
+
+        public async Task Handle(MeteringPointCreated notification, CancellationToken cancellationToken)
+        {
+            if (notification == null) throw new ArgumentNullException(nameof(notification));
+            if (EnumerationType.FromName<MeteringPointType>(notification.MeteringPointType).IsAccountingPoint)
+            {
+                await _commandScheduler.EnqueueAsync(new SetEnergySupplierInfo(
+                    notification.GsrnNumber,
+                    notification.EffectiveDate)).ConfigureAwait(false);
+            }
+        }
+    }
+}


### PR DESCRIPTION
…int is created. This is done in order to support the upcoming test

<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Add hack for setting energy supplier details as when an Accounting point is created. This is done in order to support the upcoming test
<!--- Please leave a helpful description of the pull request here. --->

## References


