### PR TITLE
Cannot remove scheduled meter reading date if field is required

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/Create/Consumption/InvalidScheduledMeterReadingDateNetSettlementGroupRuleErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/Create/Consumption/InvalidScheduledMeterReadingDateNetSettlementGroupRuleErrorConverter.cs
@@ -23,7 +23,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters.
         protected override ErrorMessage Convert(InvalidScheduledMeterReadingDateNetSettlementGroupRuleError validationError)
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
-            return new ErrorMessage("D02", "Day of scheduled meter reading date must be 01 when net settlement group is 6.");
+            return new ErrorMessage("E0H", "Day of scheduled meter reading date must be 01 when net settlement group is 6.");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/ScheduledMeterReadingDateIsRequiredErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/ScheduledMeterReadingDateIsRequiredErrorConverter.cs
@@ -13,20 +13,19 @@
 // limitations under the License.
 
 using System;
-using Energinet.DataHub.MeteringPoints.Application.Create.Validation;
 using Energinet.DataHub.MeteringPoints.Application.EDI;
-using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Errors;
 
-namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters.Create.Consumption
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters
 {
-    public class ScheduledMeterReadingDateIsRequiredRuleErrorConverter : ErrorConverter<ScheduledMeterReadingDateIsRequiredRuleError>
+    public class ScheduledMeterReadingDateIsRequiredErrorConverter : ErrorConverter<ScheduledMeterReadingDateIsRequired>
     {
-        protected override ErrorMessage Convert(ScheduledMeterReadingDateIsRequiredRuleError validationError)
+        protected override ErrorMessage Convert(ScheduledMeterReadingDateIsRequired validationError)
         {
             if (validationError == null) throw new ArgumentNullException(nameof(validationError));
             return new ErrorMessage(
-                "D02",
-                "First meter reading date for consumption metering point is missing (type E17) or not allowed (other types)");
+                "E0H",
+                "Scheduled meter reading date is required.");
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/ConsumptionMeteringPointTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/ConsumptionMeteringPointTests.cs
@@ -216,7 +216,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
 
             await SendCommandAsync(request).ConfigureAwait(false);
 
-            AssertValidationError("D02", DocumentType.RejectCreateMeteringPoint);
+            AssertValidationError("E0H", DocumentType.RejectCreateMeteringPoint);
         }
 
         [Fact]
@@ -231,7 +231,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
 
             await SendCommandAsync(request).ConfigureAwait(false);
 
-            AssertValidationError("D02", DocumentType.RejectCreateMeteringPoint);
+            AssertValidationError("E0H", DocumentType.RejectCreateMeteringPoint);
         }
 
         [Fact]

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ConsumptionMeteringPoints/ChangeTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ConsumptionMeteringPoints/ChangeTests.cs
@@ -15,14 +15,10 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
-using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.Addresses;
-using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.MeteringDetails;
-using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling;
-using NodaTime.Text;
 using Xunit;
 using Xunit.Categories;
 
@@ -37,26 +33,6 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.UpdateMasterData.Con
             : base(databaseFixture)
         {
             _timeProvider = GetService<ISystemDateTimeProvider>();
-        }
-
-        [Fact]
-        public async Task Scheduled_meter_reading_date_is_changed()
-        {
-            await SendCommandAsync(Scenarios.CreateConsumptionMeteringPointCommand() with
-            {
-                ScheduledMeterReadingDate = "0101",
-            }).ConfigureAwait(false);
-
-            var request = CreateUpdateRequest()
-                with
-                {
-                    ScheduledMeterReadingDate = "0201",
-                };
-
-            await SendCommandAsync(request).ConfigureAwait(false);
-
-            AssertMasterData()
-                .HasScheduledMeterReadingDate("0201");
         }
 
         [Fact]

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ScheduledMeterReadingDateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ScheduledMeterReadingDateTests.cs
@@ -62,5 +62,21 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.UpdateMasterData
 
             AssertValidationError("E86");
         }
+
+        [Fact]
+        public async Task Cannot_be_removed_if_required()
+        {
+            await CreateConsumptionMeteringPointInNetSettlementGroup6Async().ConfigureAwait(false);
+
+            var request = CreateUpdateRequest()
+                with
+                {
+                    ScheduledMeterReadingDate = string.Empty,
+                };
+
+            await SendCommandAsync(request).ConfigureAwait(false);
+
+            AssertValidationError("E0H");
+        }
     }
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Cannot remove scheduled meter reading date if field is required
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #551 
