### PR TITLE
Child metering point can be decoupled from parent via update master data business process

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
@@ -93,7 +93,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.ChangeMasterData
 
             targetMeteringPoint.UpdateMasterData(updatedMasterData, GetMasterValidator());
 
-            var parentCouplingResult = await CoupleToParentIfRequestedAsync(request, targetMeteringPoint).ConfigureAwait(false);
+            var parentCouplingResult = await HandleParentChildCouplingAsync(request, targetMeteringPoint).ConfigureAwait(false);
             return parentCouplingResult.Success == false ? parentCouplingResult : BusinessProcessResult.Ok(request.TransactionId);
         }
 
@@ -160,7 +160,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.ChangeMasterData
             return Task.FromResult<BusinessRulesValidationResult>(new BusinessRulesValidationResult(validationErrors));
         }
 
-        private Task<BusinessProcessResult> CoupleToParentIfRequestedAsync(ChangeMasterDataRequest request, MeteringPoint meteringPoint)
+        private Task<BusinessProcessResult> HandleParentChildCouplingAsync(ChangeMasterDataRequest request, MeteringPoint meteringPoint)
         {
             if (request.ParentRelatedMeteringPoint is null)
                 return Task.FromResult(BusinessProcessResult.Ok(request.TransactionId));

--- a/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
@@ -162,8 +162,13 @@ namespace Energinet.DataHub.MeteringPoints.Application.ChangeMasterData
 
         private Task<BusinessProcessResult> CoupleToParentIfRequestedAsync(ChangeMasterDataRequest request, MeteringPoint meteringPoint)
         {
-            if (string.IsNullOrEmpty(request.ParentRelatedMeteringPoint))
+            if (request.ParentRelatedMeteringPoint is null)
                 return Task.FromResult(BusinessProcessResult.Ok(request.TransactionId));
+
+            if (request.ParentRelatedMeteringPoint.Length == 0)
+            {
+                return _parentChildCoupling.DecoupleFromParentAsync(meteringPoint, request.TransactionId);
+            }
 
             return _parentChildCoupling.TryCoupleToParentAsync(meteringPoint, request.ParentRelatedMeteringPoint, request.TransactionId);
         }

--- a/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataHandler.cs
@@ -21,7 +21,6 @@ using Energinet.DataHub.MeteringPoints.Application.Common;
 using Energinet.DataHub.MeteringPoints.Application.Common.ChildMeteringPoints;
 using Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling;
-using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.Addresses;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Domain.Policies;
 using Energinet.DataHub.MeteringPoints.Domain.SeedWork;

--- a/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataRequestValidator.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/ChangeMasterData/ChangeMasterDataRequestValidator.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Energinet.DataHub.MeteringPoints.Application.Create.Validation;
 using Energinet.DataHub.MeteringPoints.Application.Validation.Rules;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using FluentValidation;
 
 namespace Energinet.DataHub.MeteringPoints.Application.ChangeMasterData
@@ -27,6 +29,10 @@ namespace Energinet.DataHub.MeteringPoints.Application.ChangeMasterData
                 .SetValidator(new EffectiveDateRule());
             RuleFor(request => request.TransactionId)
                 .SetValidator(new TransactionIdentificationRule());
+            RuleFor(request => request.ParentRelatedMeteringPoint)
+                .Must(value => GsrnNumber.CheckRules(value!).Success)
+                .WithState(request => new InvalidParentGsrnNumber())
+                .Unless(request => string.IsNullOrEmpty(request.ParentRelatedMeteringPoint));
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Common/ChildMeteringPoints/ParentChildCoupling.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Common/ChildMeteringPoints/ParentChildCoupling.cs
@@ -54,5 +54,12 @@ namespace Energinet.DataHub.MeteringPoints.Application.Common.ChildMeteringPoint
             await childMeteringPoint.CoupleToAsync(parentMeteringPoint).ConfigureAwait(false);
             return BusinessProcessResult.Ok(transactionId);
         }
+
+        internal Task<BusinessProcessResult> DecoupleFromParentAsync(MeteringPoint child, string transactionId)
+        {
+            var childMeteringPoint = new ChildMeteringPoint(child, _gridAreaRepository);
+            childMeteringPoint.Decouple();
+            return Task.FromResult(BusinessProcessResult.Ok(transactionId));
+        }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Common/ChildMeteringPoints/ParentChildCoupling.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Common/ChildMeteringPoints/ParentChildCoupling.cs
@@ -38,7 +38,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Common.ChildMeteringPoint
         {
             if (child == null) throw new ArgumentNullException(nameof(child));
 
-            var childMeteringPoint = new ChildMeteringPoint(child, _gridAreaRepository);
+            var childMeteringPoint = CreateChildMeteringPoint(child);
             var parentMeteringPoint = await _meteringPointRepository.GetByGsrnNumberAsync(GsrnNumber.Create(parentGsrnNumber)).ConfigureAwait(false);
             if (parentMeteringPoint is null)
             {
@@ -57,9 +57,14 @@ namespace Energinet.DataHub.MeteringPoints.Application.Common.ChildMeteringPoint
 
         internal Task<BusinessProcessResult> DecoupleFromParentAsync(MeteringPoint child, string transactionId)
         {
-            var childMeteringPoint = new ChildMeteringPoint(child, _gridAreaRepository);
+            var childMeteringPoint = CreateChildMeteringPoint(child);
             childMeteringPoint.Decouple();
             return Task.FromResult(BusinessProcessResult.Ok(transactionId));
+        }
+
+        private ChildMeteringPoint CreateChildMeteringPoint(MeteringPoint child)
+        {
+            return new ChildMeteringPoint(child, _gridAreaRepository);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/Events/DecoupledFromParent.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/Events/DecoupledFromParent.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.Events
+{
+    public class DecoupledFromParent : DomainEventBase
+    {
+        public DecoupledFromParent(Guid childMeteringPointId, Guid parentMeteringPointId)
+        {
+            ChildMeteringPointId = childMeteringPointId;
+            ParentMeteringPointId = parentMeteringPointId;
+        }
+
+        public Guid ChildMeteringPointId { get; }
+
+        public Guid ParentMeteringPointId { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/MeteringPoint.cs
@@ -200,6 +200,13 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints
             }
         }
 
+        internal void RemoveParent()
+        {
+            if (_parentMeteringPoint is null) return;
+            AddDomainEvent(new DecoupledFromParent(Id.Value, _parentMeteringPoint.Value));
+            _parentMeteringPoint = null;
+        }
+
         private bool IsClosedDown()
         {
             return ConnectionState.PhysicalState == PhysicalState.ClosedDown;

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/ChildMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/ChildMeteringPoint.cs
@@ -66,6 +66,11 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.ParentChild
             _meteringPoint.SetParent(parent.Id);
         }
 
+        public void Decouple()
+        {
+            _meteringPoint.RemoveParent();
+        }
+
         private async Task<bool> GridAreasMatchAsync(MeteringPoint parent)
         {
             if (parent == null) throw new ArgumentNullException(nameof(parent));

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/AssertPersistedMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/AssertPersistedMeteringPoint.cs
@@ -226,15 +226,15 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             return this;
         }
 
-        public AssertPersistedMeteringPoint HasParentMeteringPoint(string gsrnNumber)
+        public AssertPersistedMeteringPoint HasParentMeteringPoint(string? gsrnNumber)
         {
-            var parent = _connectionFactory.GetOpenConnection().QuerySingle(
+            var parent = _connectionFactory.GetOpenConnection().QuerySingleOrDefault(
                 $"SELECT pmp.GsrnNumber" +
                 $" FROM [dbo].[MeteringPoints] mp" +
                 $" JOIN [dbo].[MeteringPoints] pmp ON pmp.Id = mp.ParentRelatedMeteringPoint" +
                 $" WHERE mp.GsrnNumber = {_meteringPoint.GsrnNumber}");
 
-            Assert.Equal(gsrnNumber, parent.GsrnNumber);
+            Assert.Equal(gsrnNumber, parent?.GsrnNumber);
             return this;
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ParentChildCouplingTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ParentChildCouplingTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Threading.Tasks;
+using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling;
 using Xunit;
@@ -23,6 +24,9 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.UpdateMasterData
     [IntegrationTest]
     public class ParentChildCouplingTests : TestHost
     {
+        private readonly string _parentGsrnNumber = "570851247381952311";
+        private readonly string _childGsrnNumber = SampleData.GsrnNumber;
+
         public ParentChildCouplingTests(DatabaseFixture databaseFixture)
             : base(databaseFixture)
         {
@@ -31,22 +35,42 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.UpdateMasterData
         [Fact]
         public async Task Child_is_coupled_to_parent()
         {
-            var createParentCommand = Scenarios.CreateCommand(MeteringPointType.Production) with
-            {
-                GsrnNumber = "570851247381952311",
-            };
-            await SendCommandAsync(createParentCommand).ConfigureAwait(false);
-            var createChildCommand = Scenarios.CreateCommand(MeteringPointType.ElectricalHeating);
-            await SendCommandAsync(createChildCommand).ConfigureAwait(false);
+            await SetupScenario().ConfigureAwait(false);
 
             await SendCommandAsync(CreateUpdateRequest()
                 with
                 {
-                    ParentRelatedMeteringPoint = createParentCommand.GsrnNumber,
+                    ParentRelatedMeteringPoint = _parentGsrnNumber,
                 }).ConfigureAwait(false);
 
-            AssertMasterData(createChildCommand.GsrnNumber)
-                .HasParentMeteringPoint(createParentCommand.GsrnNumber);
+            AssertMasterData(_childGsrnNumber)
+                .HasParentMeteringPoint(_parentGsrnNumber);
+        }
+
+        [Fact]
+        public async Task Parent_gsrn_number_must_be_valid()
+        {
+            await SetupScenario().ConfigureAwait(false);
+
+            var request = CreateUpdateRequest()
+                with
+                {
+                    ParentRelatedMeteringPoint = "invalid gsrn number",
+                };
+            await SendCommandAsync(request).ConfigureAwait(false);
+
+            AssertValidationError("E10");
+        }
+
+        private async Task SetupScenario()
+        {
+            var createParentCommand = Scenarios.CreateCommand(MeteringPointType.Production) with
+            {
+                GsrnNumber = _parentGsrnNumber,
+            };
+            await SendCommandAsync(createParentCommand).ConfigureAwait(false);
+            var createChildCommand = Scenarios.CreateCommand(MeteringPointType.ElectricalHeating);
+            await SendCommandAsync(createChildCommand).ConfigureAwait(false);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/ParentChildTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/ParentChildTests.cs
@@ -89,6 +89,19 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Domain.MeteringPoints
             Assert.Contains(child.DomainEvents, e => e is CoupledToParent);
         }
 
+        [Fact]
+        public async Task Decoupling_is_successful()
+        {
+            var parent = CreateMeteringPoint(MeteringPointType.Consumption);
+            var child = CreateMeteringPoint(MeteringPointType.NetConsumption);
+            var childMeteringPoint = new ChildMeteringPoint(child, _gridAreaRepository);
+            await childMeteringPoint.CoupleToAsync(parent).ConfigureAwait(false);
+
+            childMeteringPoint.Decouple();
+
+            Assert.Contains(child.DomainEvents, e => e is DecoupledFromParent);
+        }
+
         private ChildMeteringPoint CreateChildMeteringPoint(MeteringPointType type)
         {
             return new ChildMeteringPoint(CreateMeteringPoint(type), _gridAreaRepository);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Child metering point can be decoupled from parent via update master data business process
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #551 
