### PR TITLE
Cannot couple child to a closed down parent metering point

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/ChildMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/ChildMeteringPoint.cs
@@ -48,6 +48,7 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.ParentChild
                 new OnlySpecificGroupsCanActAsParentRule(parent),
                 new OnlyGroup3And4CanActAsChildOfGroup1(parent, _meteringPoint),
                 new OnlySpecificGroupsCanActAsChildOfGroup2(parent, _meteringPoint),
+                new CannotCoupleToClosedDownParentRule(parent),
             };
 
             errors.AddRange(rules.Where(rule => rule.IsBroken).Select(rule => rule.ValidationError).ToList());

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/Rules/CannotCoupleToClosedDownParent.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/Rules/CannotCoupleToClosedDownParent.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.ParentChild.Rules
+{
+    public class CannotCoupleToClosedDownParent : ValidationError
+    {
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/Rules/CannotCoupleToClosedDownParentRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MeteringPoints/ParentChild/Rules/CannotCoupleToClosedDownParentRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
+
+namespace Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.ParentChild.Rules
+{
+    public class CannotCoupleToClosedDownParentRule : IBusinessRule
+    {
+        public CannotCoupleToClosedDownParentRule(MeteringPoint parent)
+        {
+            if (parent == null) throw new ArgumentNullException(nameof(parent));
+            IsBroken = parent.ConnectionState.PhysicalState == PhysicalState.ClosedDown;
+        }
+
+        public bool IsBroken { get; }
+
+        public ValidationError ValidationError => new CannotCoupleToClosedDownParent();
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/ParentChild/CannotCoupleToClosedDownParentErrorConverter.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/Errors/Converters/ParentChild/CannotCoupleToClosedDownParentErrorConverter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Energinet.DataHub.MeteringPoints.Application.EDI;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.ParentChild.Rules;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors.Converters.ParentChild
+{
+    public class CannotCoupleToClosedDownParentErrorConverter : ErrorConverter<CannotCoupleToClosedDownParent>
+    {
+        protected override ErrorMessage Convert(CannotCoupleToClosedDownParent validationError)
+        {
+            return new ErrorMessage("D16", "Cannot couple to a closed down parent metering point.");
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/ParentChildTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/ParentChildTests.cs
@@ -32,6 +32,26 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
         }
 
         [Fact]
+        public async Task Reject_if_parent_is_closed_down()
+        {
+            var createParentCommand = Scenarios.CreateCommand(MeteringPointType.Production) with
+            {
+                GsrnNumber = "570851247381952311",
+            };
+            await SendCommandAsync(createParentCommand).ConfigureAwait(false);
+            await CloseDownMeteringPointAsync(createParentCommand.GsrnNumber).ConfigureAwait(false);
+
+            var createChildCommand = Scenarios.CreateCommand(MeteringPointType.ElectricalHeating)
+                with
+                {
+                    ParentRelatedMeteringPoint = createParentCommand.GsrnNumber,
+                };
+            await SendCommandAsync(createChildCommand).ConfigureAwait(false);
+
+            AssertValidationError("D16");
+        }
+
+        [Fact]
         public async Task Reject_when_parent_can_not_act_as_parent()
         {
             var createInvalidParentCommand = Scenarios.CreateCommand(MeteringPointType.NetConsumption) with

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -437,10 +437,15 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             await SendCommandAsync(request).ConfigureAwait(false);
         }
 
-        protected async Task CloseDownMeteringPointAsync()
+        protected Task CloseDownMeteringPointAsync()
+        {
+            return CloseDownMeteringPointAsync(SampleData.GsrnNumber);
+        }
+
+        protected async Task CloseDownMeteringPointAsync(string gsrnNumber)
         {
             var context = GetService<MeteringPointContext>();
-            var meteringPoint = context.MeteringPoints.First(meteringPoint => meteringPoint.GsrnNumber.Equals(GsrnNumber.Create(SampleData.GsrnNumber)));
+            var meteringPoint = context.MeteringPoints.First(meteringPoint => meteringPoint.GsrnNumber.Equals(GsrnNumber.Create(gsrnNumber)));
             meteringPoint?.CloseDown();
             await context.SaveChangesAsync().ConfigureAwait(false);
         }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ParentChildCouplingTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/UpdateMasterData/ParentChildCouplingTests.cs
@@ -32,6 +32,22 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.UpdateMasterData
         }
 
         [Fact]
+        public async Task Reject_if_parent_is_closed_down()
+        {
+            await CreateParentAndChild().ConfigureAwait(false);
+            await CloseDownMeteringPointAsync(_parentGsrnNumber).ConfigureAwait(false);
+
+            var request = CreateUpdateRequest()
+                with
+                {
+                    ParentRelatedMeteringPoint = _parentGsrnNumber,
+                };
+            await SendCommandAsync(request).ConfigureAwait(false);
+
+            AssertValidationError("D16");
+        }
+
+        [Fact]
         public async Task Parent_and_child_must_be_in_same_grid_area()
         {
             await CreateParentAndChildIn("870", "871").ConfigureAwait(false);

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/ParentChildTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Domain/MeteringPoints/ParentChildTests.cs
@@ -38,6 +38,17 @@ namespace Energinet.DataHub.MeteringPoints.Tests.Domain.MeteringPoints
         }
 
         [Fact]
+        public async Task Can_not_couple_to_a_parent_that_is_closed_down()
+        {
+            var parent = CreateMeteringPoint(MeteringPointType.Consumption, CreateGridArea());
+            var childMeteringPoint = CreateChildMeteringPoint(MeteringPointType.ElectricalHeating);
+            parent.CloseDown();
+
+            AssertContainsValidationError<CannotCoupleToClosedDownParent>(await childMeteringPoint.CanCoupleToAsync(parent).ConfigureAwait(false));
+            await Assert.ThrowsAsync<ParentCouplingException>(() => childMeteringPoint.CoupleToAsync(parent)).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task Parent_and_child_metering_points_must_reside_in_the_same_grid_area()
         {
             var parent = CreateMeteringPoint(MeteringPointType.Consumption, CreateGridArea());


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Cannot couple child to a closed down parent metering point
<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #551
