### PR TITLE
Fix: `MeteringPointCreatedEventMessage` incorrectly used `OccurredOn` instead of `EffectiveDate`

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/IntegrationEvents/CreateMeteringPoint/MeteringPointCreatedNotificationHandler.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/IntegrationEvents/CreateMeteringPoint/MeteringPointCreatedNotificationHandler.cs
@@ -48,7 +48,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.Integration.Integratio
                 notification.ProductType,
                 notification.UnitType,
                 string.Empty,
-                notification.OccurredOn);
+                notification.EffectiveDate);
 
             CreateAndAddOutboxMessage(message);
 


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

During a test in the Charges domain, it was discovered that the persisted effective date in the Charges domain didn't match effective date in the Metering Point domain.

This PR fixes the problem, by using `EffectiveDate` instead of `OccurredOn` when creating `MeteringPointCreatedEventMessage`.

Metering Point domain:

![image](https://user-images.githubusercontent.com/71757561/152323590-0432795a-0db4-43dc-be72-35a50e850d24.png)

Charges domain:

![image](https://user-images.githubusercontent.com/71757561/152323652-cac07075-79a1-42f7-af6c-6d1dd8bf9b96.png)


<!--- Please leave a helpful description of the pull request here. --->

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
