### PR TITLE
Refactor composition roots away from handler assembly scanning

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/MediatorBuilder.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/MediatorBuilder.cs
@@ -1,0 +1,92 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using MediatR;
+using MediatR.Pipeline;
+using SimpleInjector;
+
+namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
+{
+    public class MediatorBuilder
+    {
+        private readonly Container _container;
+
+        internal MediatorBuilder(Container container)
+        {
+            _container = container;
+
+            RegisterDefaults();
+        }
+
+        public MediatorBuilder WithPipeline(params Type[] pipelineBehaviors)
+        {
+            // Add built-in pipeline behaviors
+            var builtInBehaviors = new[]
+            {
+                typeof(RequestHandlerTelemetryBehavior<,>),
+                typeof(RequestExceptionProcessorBehavior<,>),
+                typeof(RequestExceptionActionProcessorBehavior<,>),
+                typeof(RequestPreProcessorBehavior<,>),
+                typeof(RequestPostProcessorBehavior<,>),
+            };
+
+            // Register both built-in and custom pipeline
+            _container.Collection.Register(typeof(IPipelineBehavior<,>), builtInBehaviors.Union(pipelineBehaviors));
+
+            return this;
+        }
+
+        public MediatorBuilder WithRequestHandlers(params Type[] handlers)
+        {
+            _container.Register(typeof(IRequestHandler<,>), handlers);
+
+            return this;
+        }
+
+        public MediatorBuilder WithNotificationHandlers(params Type[] handlers)
+        {
+            _container.Collection.Register(typeof(INotificationHandler<>), handlers);
+            _container.RegisterDecorator(typeof(INotificationHandler<>), typeof(NotificationHandlerTelemetryDecorator<>));
+
+            return this;
+        }
+
+        private void RegisterDefaults()
+        {
+            _container.RegisterSingleton<IMediator, Mediator>();
+
+            _container.Collection.Register(typeof(IRequestPreProcessor<>), new[] { typeof(EmptyRequestPreProcessor<>) });
+            _container.Collection.Register(typeof(IRequestPostProcessor<,>), new[] { typeof(EmptyRequestPostProcessor<,>) });
+
+            var mediatrAssemblies = new[] { typeof(IMediator).GetTypeInfo().Assembly };
+            RegisterHandlers(typeof(IRequestExceptionAction<,>), mediatrAssemblies);
+            RegisterHandlers(typeof(IRequestExceptionHandler<,,>), mediatrAssemblies);
+
+            _container.Register(() => new ServiceFactory(_container.GetInstance), Lifestyle.Singleton);
+        }
+
+        private void RegisterHandlers(Type collectionType, Assembly[] assemblies)
+        {
+            var handlerTypes = _container.GetTypesToRegister(collectionType, assemblies, new TypesToRegisterOptions
+            {
+                IncludeGenericTypeDefinitions = true,
+                IncludeComposites = false,
+            });
+            _container.Collection.Register(collectionType, handlerTypes);
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
@@ -12,72 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using MediatR;
-using MediatR.Pipeline;
 using SimpleInjector;
 
 namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
 {
-    // Note: https://github.com/jbogard/MediatR/tree/master/samples/MediatR.Examples.SimpleInjector
     public static class SimpleInjectorMediatorContainerExtensions
     {
         public static MediatorBuilder UseMediatR(this Container container)
         {
             return new MediatorBuilder(container);
-        }
-
-        public static void BuildMediator(this Container container, Assembly[] applicationAssemblies, Type[] pipelineBehaviors)
-        {
-            if (container == null) throw new ArgumentNullException(nameof(container));
-
-            var assemblies = GetMediatorAssemblies().Union(applicationAssemblies).ToArray();
-            container.RegisterSingleton<IMediator, Mediator>();
-            container.Register(typeof(IRequestHandler<,>), assemblies);
-
-            RegisterHandlers(container, typeof(INotificationHandler<>), assemblies);
-            container.RegisterDecorator(typeof(INotificationHandler<>), typeof(NotificationHandlerTelemetryDecorator<>));
-
-            RegisterHandlers(container, typeof(IRequestExceptionAction<,>), assemblies);
-            RegisterHandlers(container, typeof(IRequestExceptionHandler<,,>), assemblies);
-
-            // Add built-in pipeline behaviors
-            var builtInBehaviors = new[]
-            {
-                typeof(RequestHandlerTelemetryBehavior<,>),
-                typeof(RequestExceptionProcessorBehavior<,>),
-                typeof(RequestExceptionActionProcessorBehavior<,>),
-                typeof(RequestPreProcessorBehavior<,>),
-                typeof(RequestPostProcessorBehavior<,>),
-            };
-
-            // Register both built-in and custom pipeline
-            container.Collection.Register(typeof(IPipelineBehavior<,>), builtInBehaviors.Union(pipelineBehaviors));
-
-            container.Collection.Register(typeof(IRequestPreProcessor<>), new[] { typeof(EmptyRequestPreProcessor<>) });
-            container.Collection.Register(typeof(IRequestPostProcessor<,>), new[] { typeof(EmptyRequestPostProcessor<,>) });
-
-            container.Register(() => new ServiceFactory(container.GetInstance), Lifestyle.Singleton);
-        }
-
-        private static void RegisterHandlers(Container container, Type collectionType, Assembly[] assemblies)
-        {
-            // we have to do this because by default, generic type definitions (such as the Constrained Notification Handler) won't be registered
-            var handlerTypes = container.GetTypesToRegister(collectionType, assemblies, new TypesToRegisterOptions
-            {
-                IncludeGenericTypeDefinitions = true,
-                IncludeComposites = false,
-            });
-
-            container.Collection.Register(collectionType, handlerTypes);
-        }
-
-        private static IEnumerable<Assembly> GetMediatorAssemblies()
-        {
-            yield return typeof(IMediator).GetTypeInfo().Assembly;
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
@@ -30,39 +30,6 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
             return new MediatorBuilder(container);
         }
 
-        public static void BuildMinimalMediator(this Container container, Assembly assembly, params Type[] types)
-        {
-            if (container == null) throw new ArgumentNullException(nameof(container));
-            if (types == null) throw new ArgumentNullException(nameof(types));
-
-            container.RegisterSingleton<IMediator, Mediator>();
-            foreach (var type in types)
-            {
-                container.Register(type, assembly);
-            }
-
-            RegisterHandlers(container, typeof(IRequestExceptionAction<,>), new[] { assembly });
-            RegisterHandlers(container, typeof(IRequestExceptionHandler<,,>), new[] { assembly });
-
-            // Add built-in pipeline behaviors
-            var builtInBehaviors = new[]
-            {
-                typeof(RequestHandlerTelemetryBehavior<,>),
-                typeof(RequestExceptionProcessorBehavior<,>),
-                typeof(RequestExceptionActionProcessorBehavior<,>),
-                typeof(RequestPreProcessorBehavior<,>),
-                typeof(RequestPostProcessorBehavior<,>),
-            };
-
-            // Register both built-in and custom pipeline
-            container.Collection.Register(typeof(IPipelineBehavior<,>), builtInBehaviors);
-
-            container.Collection.Register(typeof(IRequestPreProcessor<>), new[] { typeof(EmptyRequestPreProcessor<>) });
-            container.Collection.Register(typeof(IRequestPostProcessor<,>), new[] { typeof(EmptyRequestPostProcessor<,>) });
-
-            container.Register(() => new ServiceFactory(container.GetInstance), Lifestyle.Singleton);
-        }
-
         public static void BuildMediator(this Container container, Assembly[] applicationAssemblies, Type[] pipelineBehaviors)
         {
             if (container == null) throw new ArgumentNullException(nameof(container));

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/SimpleInjectorMediatorContainerExtensions.cs
@@ -25,6 +25,11 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
     // Note: https://github.com/jbogard/MediatR/tree/master/samples/MediatR.Examples.SimpleInjector
     public static class SimpleInjectorMediatorContainerExtensions
     {
+        public static MediatorBuilder UseMediatR(this Container container)
+        {
+            return new MediatorBuilder(container);
+        }
+
         public static void BuildMinimalMediator(this Container container, Assembly assembly, params Type[] types)
         {
             if (container == null) throw new ArgumentNullException(nameof(container));
@@ -49,7 +54,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
                 typeof(RequestPostProcessorBehavior<,>),
             };
 
-            // Register built both-in and custom pipeline
+            // Register both built-in and custom pipeline
             container.Collection.Register(typeof(IPipelineBehavior<,>), builtInBehaviors);
 
             container.Collection.Register(typeof(IRequestPreProcessor<>), new[] { typeof(EmptyRequestPreProcessor<>) });
@@ -82,7 +87,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
                 typeof(RequestPostProcessorBehavior<,>),
             };
 
-            // Register built both-in and custom pipeline
+            // Register both built-in and custom pipeline
             container.Collection.Register(typeof(IPipelineBehavior<,>), builtInBehaviors.Union(pipelineBehaviors));
 
             container.Collection.Register(typeof(IRequestPreProcessor<>), new[] { typeof(EmptyRequestPreProcessor<>) });

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
@@ -46,7 +46,6 @@ using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Confirm;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Generic;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Reject;
 using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
-using MediatR;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -110,13 +109,14 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub
             container.Register<IMessageDispatcher, InternalDispatcher>(Lifestyle.Scoped);
             container.Register<Channel, InternalServiceBus>(Lifestyle.Scoped);
             container.Register<IActorContext, ActorContext>(Lifestyle.Scoped);
-            container.BuildMinimalMediator(typeof(BundleHandler<>).Assembly, Array.Empty<Type>());
 
-            // TODO: register with assembly scan once assemblies have been split.
-            container.Register<IRequestHandler<BundleRequest<ConfirmMessage>, string>, ConfirmMessageBundleHandler>(Lifestyle.Scoped);
-            container.Register<IRequestHandler<BundleRequest<RejectMessage>, string>, RejectMessageBundleHandler>(Lifestyle.Scoped);
-            container.Register<IRequestHandler<BundleRequest<GenericNotificationMessage>, string>, GenericNotificationBundleHandler>(Lifestyle.Scoped);
-            container.Register<IRequestHandler<BundleRequest<AccountingPointCharacteristicsMessage>, string>, AccountingPointCharacteristicsBundleHandler>(Lifestyle.Scoped);
+            container.UseMediatR()
+                .WithPipeline()
+                .WithRequestHandlers(
+                    typeof(ConfirmMessageBundleHandler),
+                    typeof(RejectMessageBundleHandler),
+                    typeof(GenericNotificationBundleHandler),
+                    typeof(AccountingPointCharacteristicsBundleHandler));
 
             var messageHubStorageConnectionString = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONNECTION_STRING") ?? throw new InvalidOperationException("MessageHub storage connection string not found.");
             var messageHubStorageContainerName = Environment.GetEnvironmentVariable("MESSAGEHUB_STORAGE_CONTAINER_NAME") ?? throw new InvalidOperationException("MessageHub storage container name not found.");

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
@@ -50,9 +50,11 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.ContainerExtensions;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Correlation;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.EnergySuppliers;
+using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.EnergySuppliers.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.GridAreas;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MessageHub.Bundling;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DomainEventDispatching;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.AccountingPointCharacteristics;
@@ -64,8 +66,15 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.CreateMeteringPoint;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.DisconnectMeteringPoint;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.GenericNotification;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.ChargeLinks.Create;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Connect;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Consumption;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Exchange;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Production;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Disconnect;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Reconnect;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.Notifications;
 using Energinet.DataHub.MeteringPoints.Infrastructure.InternalCommands;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Messaging.Idempotency;
@@ -207,21 +216,36 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing
                 typeof(MeteringPoint).Assembly, // Domain
                 typeof(ErrorMessageFactory).Assembly); // Infrastructure
 
-            // Setup pipeline behaviors
-            container.BuildMediator(
-                new[]
-                {
-                    typeof(MasterDataDocument).Assembly,
-                    typeof(MeteringPointCreatedNotificationHandler).Assembly,
-                },
-                new[]
-                {
+            container.UseMediatR()
+                .WithPipeline(
                     typeof(UnitOfWorkBehavior<,>),
                     typeof(InputValidationBehavior<,>),
                     typeof(DomainEventsDispatcherBehaviour<,>),
                     typeof(InternalCommandHandlingBehaviour<,>),
-                    typeof(BusinessProcessResultBehavior<,>),
-                });
+                    typeof(BusinessProcessResultBehavior<,>))
+                .WithRequestHandlers(
+                    typeof(UpdateMasterDataHandler),
+                    typeof(MasterDataDocumentHandler),
+                    typeof(DisconnectReconnectMeteringPointHandler),
+                    typeof(CreateMeteringPointHandler),
+                    typeof(AddEnergySupplierHandler),
+                    typeof(ConnectMeteringPointHandler),
+                    typeof(SendAccountingPointCharacteristicsMessageHandler),
+                    typeof(SetEnergySupplierDetailsHandler),
+                    typeof(RequestCloseDownHandler),
+                    typeof(CreateDefaultChargeLinksHandler),
+                    typeof(MeteringPointByIdQueryHandler),
+                    typeof(MeteringPointGsrnExistsQueryHandler),
+                    typeof(EnergySuppliersByMeteringPointIdQueryHandler))
+                .WithNotificationHandlers(
+                    typeof(MeteringPointCreatedNotificationHandler),
+                    typeof(OnProductionMeteringPointCreated),
+                    typeof(OnConsumptionMeteringPointCreated),
+                    typeof(OnExchangeMeteringPointCreated),
+                    typeof(OnMeteringPointConnected),
+                    typeof(OnMeteringPointDisconnected),
+                    typeof(OnMeteringPointReconnected),
+                    typeof(SetEnergySupplierHACK));
 
             Dapper.SqlMapper.AddTypeHandler(NodaTimeSqlMapper.Instance);
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Startup.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Startup.cs
@@ -19,8 +19,6 @@ using Energinet.DataHub.Core.App.WebApp.SimpleInjector;
 using Energinet.DataHub.MeteringPoints.Application.Common;
 using Energinet.DataHub.MeteringPoints.Application.Common.DomainEvents;
 using Energinet.DataHub.MeteringPoints.Application.MarketDocuments;
-using Energinet.DataHub.MeteringPoints.Application.Queries;
-using Energinet.DataHub.MeteringPoints.Client.Abstractions.Models;
 using Energinet.DataHub.MeteringPoints.Contracts;
 using Energinet.DataHub.MeteringPoints.Domain.GridAreas;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
@@ -36,7 +34,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Correlation;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.GridAreas;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints;
-using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DomainEventDispatching;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents;
@@ -45,7 +42,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf.Integration;
 using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using FluentValidation;
-using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -159,10 +155,15 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.WebApi
                 typeof(MeteringPoint).Assembly, // Domain
                 typeof(ErrorMessageFactory).Assembly); // Infrastructure
 
-            // Setup pipeline behaviors
-            _container.BuildMediator(
-                new[] { typeof(CreateGridAreaHandler).Assembly, },
-                new[] { typeof(UnitOfWorkBehavior<,>), typeof(InputValidationBehavior<,>), typeof(InternalCommandHandlingBehaviour<,>), typeof(BusinessProcessResultBehavior<,>), });
+            _container.UseMediatR()
+                .WithPipeline(
+                    typeof(UnitOfWorkBehavior<,>),
+                    typeof(InputValidationBehavior<,>),
+                    typeof(InternalCommandHandlingBehaviour<,>),
+                    typeof(BusinessProcessResultBehavior<,>))
+                .WithRequestHandlers(
+                    typeof(CreateGridAreaHandler),
+                    typeof(MeteringPointByGsrnQueryHandler));
 
             _container.SendProtobuf<MeteringPointEnvelope>();
         }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -47,6 +47,7 @@ using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 using Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR;
 using Energinet.DataHub.MeteringPoints.EntryPoints.WebApi;
 using Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.GridAreas.Create;
+using Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.MeteringPoints.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure;
 using Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing;
 using Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Authorization;
@@ -55,9 +56,11 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.ContainerExtensions;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Correlation;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.EnergySuppliers;
+using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.EnergySuppliers.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.GridAreas;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MessageHub.Bundling;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints;
+using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess.MeteringPoints.Queries;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DomainEventDispatching;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.AccountingPointCharacteristics;
@@ -69,8 +72,15 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.CreateMeteringPoint;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.DisconnectMeteringPoint;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.Errors;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI.GenericNotification;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.ChargeLinks.Create;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Connect;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Consumption;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Exchange;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.CreateMeteringPoint.Production;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Disconnect;
+using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEvents.Reconnect;
 using Energinet.DataHub.MeteringPoints.Infrastructure.InternalCommands;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Providers.MeteringPointOwnership;
@@ -209,21 +219,38 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                 typeof(MeteringPoint).Assembly, // Domain
                 typeof(ErrorMessageFactory).Assembly); // Infrastructure
 
-            _container.BuildMediator(
-                new[]
-                {
-                    typeof(MasterDataDocument).Assembly,
-                    typeof(MeteringPointCreatedNotificationHandler).Assembly,
-                    typeof(CreateGridAreaHandler).Assembly,
-                },
-                new[]
-                {
+            _container.UseMediatR()
+                .WithPipeline(
                     typeof(UnitOfWorkBehavior<,>),
                     typeof(InputValidationBehavior<,>),
                     typeof(DomainEventsDispatcherBehaviour<,>),
                     typeof(InternalCommandHandlingBehaviour<,>),
-                    typeof(BusinessProcessResultBehavior<,>),
-                });
+                    typeof(BusinessProcessResultBehavior<,>))
+                .WithRequestHandlers(
+                    typeof(UpdateMasterDataHandler),
+                    typeof(MasterDataDocumentHandler),
+                    typeof(DisconnectReconnectMeteringPointHandler),
+                    typeof(CreateMeteringPointHandler),
+                    typeof(AddEnergySupplierHandler),
+                    typeof(ConnectMeteringPointHandler),
+                    typeof(SendAccountingPointCharacteristicsMessageHandler),
+                    typeof(SetEnergySupplierDetailsHandler),
+                    typeof(RequestCloseDownHandler),
+                    typeof(CreateDefaultChargeLinksHandler),
+                    typeof(MeteringPointByIdQueryHandler),
+                    typeof(MeteringPointGsrnExistsQueryHandler),
+                    typeof(EnergySuppliersByMeteringPointIdQueryHandler),
+                    typeof(MeteringPointByGsrnQueryHandler),
+                    typeof(CreateGridAreaHandler))
+                .WithNotificationHandlers(
+                    typeof(MeteringPointCreatedNotificationHandler),
+                    typeof(OnProductionMeteringPointCreated),
+                    typeof(OnConsumptionMeteringPointCreated),
+                    typeof(OnExchangeMeteringPointCreated),
+                    typeof(OnMeteringPointConnected),
+                    typeof(OnMeteringPointDisconnected),
+                    typeof(OnMeteringPointReconnected),
+                    typeof(SetEnergySupplierHACK));
 
             // Specific for test instead of using Application Insights package
             _container.Register(() => new TelemetryClient(new TelemetryConfiguration()), Lifestyle.Scoped);

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -26,7 +25,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Confirm;
 using FluentAssertions;
-using MediatR;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Logging;
@@ -45,8 +43,12 @@ namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub
         public async Task Bundles_should_be_created_for_multiple_documents()
         {
             await using var container = new Container();
-            container.BuildMinimalMediator(typeof(BundleHandler<>).Assembly, Array.Empty<Type>());
-            container.Register<IRequestHandler<BundleRequest<ConfirmMessage>, string>, ConfirmMessageBundleHandler>();
+
+            container.UseMediatR()
+                .WithPipeline()
+                .WithRequestHandlers(
+                    typeof(ConfirmMessageBundleHandler));
+
             container.Register<IJsonSerializer, JsonSerializer>();
             container.Register<IBundleCreator, BundleCreator>();
             container.Register<IDocumentSerializer<ConfirmMessage>, ConfirmMessageXmlSerializer>();

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
@@ -30,7 +30,7 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="1.3.1" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="1.1.1" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="1.1.2" />
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />


### PR DESCRIPTION
This PR removes the use of assembly scanning for configuring MediatR in the composition root.