### PR TITLE
Inform Balance Supplier about change in connection status (Test updates)

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ReconnectMeteringPoints/ReconnectTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/ReconnectMeteringPoints/ReconnectTests.cs
@@ -69,6 +69,22 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.ReconnectMeteringPoi
         }
 
         [Fact]
+        public async Task Send_master_data_to_associated_energy_suppliers_when_reconnected()
+        {
+            await CreateMeteringPointWithEnergySupplierAssigned().ConfigureAwait(false);
+
+            await SendCommandAsync(CreateConnectMeteringPointRequest()).ConfigureAwait(false);
+
+            await SendCommandAsync(CreateDisconnectMeteringPointRequest()).ConfigureAwait(false);
+
+            await SendCommandAsync(CreateReconnectMeteringPointRequest()).ConfigureAwait(false);
+
+            await AssertAndRunInternalCommandAsync<SendAccountingPointCharacteristicsMessage>().ConfigureAwait(false);
+
+            AssertOutboxMessage<MessageHubEnvelope>(envelope => envelope.MessageType == DocumentType.AccountingPointCharacteristicsMessage, 3);
+        }
+
+        [Fact]
         public async Task Cannot_reconnect_if_not_disconnected()
         {
             await CreateMeteringPointWithEnergySupplierAssigned().ConfigureAwait(false);
@@ -140,12 +156,23 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.ReconnectMeteringPoi
         {
             await SendCommandAsync(Scenarios.CreateCommand(MeteringPointType.Consumption)).ConfigureAwait(false);
             await MarkAsEnergySupplierAssigned(startOfSupplyDate).ConfigureAwait(false);
+            await AddEnergySupplier(startOfSupplyDate).ConfigureAwait(false);
         }
 
         private async Task MarkAsEnergySupplierAssigned(Instant startOfSupply)
         {
             var setEnergySupplierAssigned = new SetEnergySupplierInfo(SampleData.GsrnNumber, startOfSupply);
             await SendCommandAsync(setEnergySupplierAssigned).ConfigureAwait(false);
+        }
+
+        private async Task AddEnergySupplier(Instant startOfSupply)
+        {
+            var meteringPointRepository = GetService<IMeteringPointRepository>();
+            var meteringPoint = await meteringPointRepository.GetByGsrnNumberAsync(GsrnNumber.Create(SampleData.GsrnNumber))
+                .ConfigureAwait(false);
+
+            var addEnergySupplier = new AddEnergySupplier(meteringPoint?.Id.Value.ToString()!, startOfSupply, SampleData.GlnNumber);
+            await SendCommandAsync(addEnergySupplier).ConfigureAwait(false);
         }
 
         private ConnectMeteringPointRequest CreateConnectMeteringPointRequest()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

 When the connection status of a metering point goes from connected to disconnected an RSM-022 business reason code E79 is sent to the balance supplier
 When the connection status of a metering point goes from disconnected to connected an RSM-022 with business reason code E79 is sent to the balance supplier

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

https://app.zenhub.com/workspaces/batman-60a6105157304f00119be86e/issues/energinet-datahub/geh-metering-point/741
