### PR TITLE
Add system timer function

### DIFF
--- a/build/infrastructure/main/func-processing.tf
+++ b/build/infrastructure/main/func-processing.tf
@@ -37,7 +37,7 @@ module "func_processing" {
     INTEGRATION_EVENT_QUEUE                 = data.azurerm_key_vault_secret.metering_point_forwarded_name.value
     INTEGRATION_EVENT_QUEUE_CONNECTION      = data.azurerm_key_vault_secret.sb_domain_relay_listen_connection_string.value
     CHARGES_DEFAULT_LINK_RESPONSE_QUEUE     = "create-link-reply"
-    INTERNAL_COMMAND_PROCESSING_INTERVAL    = "*/10 * * * * *"
+    RAISE_TIME_HAS_PASSED_EVENT_SCHEDULE    = "*/10 * * * * *"
   }
 
   tags                                      = azurerm_resource_group.this.tags

--- a/source/Energinet.DataHub.MeteringPoints.Application/Common/SystemTime/TimeHasPassed.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Common/SystemTime/TimeHasPassed.cs
@@ -1,0 +1,29 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using MediatR;
+using NodaTime;
+
+namespace Energinet.DataHub.MeteringPoints.Application.Common.SystemTime
+{
+    public class TimeHasPassed : INotification
+    {
+        public TimeHasPassed(Instant now)
+        {
+            Now = now;
+        }
+
+        public Instant Now { get; }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
@@ -143,7 +143,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing
 
             // Register application components.
             container.Register<QueueSubscriber>(Lifestyle.Scoped);
-            container.Register<ProcessInternalCommands>(Lifestyle.Scoped);
+            container.Register<SystemTimer>(Lifestyle.Scoped);
             container.Register<InternalCommandProcessor>(Lifestyle.Scoped);
             container.Register<InternalCommandAccessor>(Lifestyle.Scoped);
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
@@ -254,7 +254,8 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing
                     typeof(OnMeteringPointConnected),
                     typeof(OnMeteringPointDisconnected),
                     typeof(OnMeteringPointReconnected),
-                    typeof(SetEnergySupplierHACK));
+                    typeof(SetEnergySupplierHACK),
+                    typeof(ProcessInternalCommandsOnTimeHasPassed));
 
             Dapper.SqlMapper.AddTypeHandler(NodaTimeSqlMapper.Instance);
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/local.settings.sample.json
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/local.settings.sample.json
@@ -11,6 +11,6 @@
     "INTEGRATION_EVENT_QUEUE_CONNECTION": "<Service Bus connection string where integration/notification events are received>",
     "SHARED_INTEGRATION_EVENT_SERVICE_BUS_SENDER_CONNECTION_STRING": "<Shared Azure Service Bus connection string>",
     "CHARGES_DEFAULT_LINK_RESPONSE_QUEUE": "<Queue name that Charges response to in request/response pattern>",
-    "INTERNAL_COMMAND_PROCESSING_INTERVAL": "*/10 * * * * *"
+    "RAISE_TIME_HAS_PASSED_EVENT_SCHEDULE": "*/10 * * * * *"
   }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/ProcessInternalCommandsOnTimeHasPassed.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/ProcessInternalCommandsOnTimeHasPassed.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MeteringPoints.Application.Common.SystemTime;
+using MediatR;
+
+namespace Energinet.DataHub.MeteringPoints.Infrastructure.InternalCommands
+{
+    public class ProcessInternalCommandsOnTimeHasPassed : INotificationHandler<TimeHasPassed>
+    {
+        private readonly InternalCommandProcessor _internalCommandProcessor;
+
+        public ProcessInternalCommandsOnTimeHasPassed(InternalCommandProcessor internalCommandProcessor)
+        {
+            _internalCommandProcessor = internalCommandProcessor ?? throw new ArgumentNullException(nameof(internalCommandProcessor));
+        }
+
+        public Task Handle(TimeHasPassed notification, CancellationToken cancellationToken)
+        {
+            return _internalCommandProcessor.ProcessPendingAsync();
+        }
+    }
+}

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CloseDown/RequestCloseDownTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CloseDown/RequestCloseDownTests.cs
@@ -135,33 +135,6 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CloseDown
             AssertValidationError("E10");
         }
 
-        // [Fact]
-        // public async Task The_close_down_activity_is_scheduled_when_process_is_started()
-        // {
-        //     await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
-        //
-        //     var request = CreateRequest();
-        //     await ReceiveRequest(request).ConfigureAwait(false);
-        //
-        //     var command =
-        //         await GetScheduledCommandAsync<CloseDownMeteringPoint>(InstantPattern.General
-        //             .Parse(request.EffectiveDate).Value).ConfigureAwait(false);
-        //
-        //     Assert.NotNull(command);
-        //     Assert.Equal(request.GsrnNumber, command?.GsrnNumber);
-        // }
-        //
-        // [Fact]
-        // public async Task Metering_point_is_closed_down()
-        // {
-        //     await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
-        //
-        //     var command = new CloseDownMeteringPoint(SampleData.GsrnNumber);
-        //     await SendCommandAsync(command).ConfigureAwait(false);
-        //
-        //     AssertMasterData()
-        //         .HasConnectionState(PhysicalState.ClosedDown);
-        // }
         [Fact]
         public async Task Metering_point_is_closed_down_when_due_date_has_transpired()
         {

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CloseDown/RequestCloseDownTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CloseDown/RequestCloseDownTests.cs
@@ -13,14 +13,17 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Application.CloseDown;
 using Energinet.DataHub.MeteringPoints.Application.Common.ReceiveBusinessRequests;
+using Energinet.DataHub.MeteringPoints.Application.Common.SystemTime;
 using Energinet.DataHub.MeteringPoints.Application.MarketDocuments;
 using Energinet.DataHub.MeteringPoints.Domain.BusinessProcesses;
 using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling;
+using MediatR;
 using NodaTime.Text;
 using Xunit;
 using Xunit.Categories;
@@ -132,29 +135,41 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CloseDown
             AssertValidationError("E10");
         }
 
+        // [Fact]
+        // public async Task The_close_down_activity_is_scheduled_when_process_is_started()
+        // {
+        //     await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
+        //
+        //     var request = CreateRequest();
+        //     await ReceiveRequest(request).ConfigureAwait(false);
+        //
+        //     var command =
+        //         await GetScheduledCommandAsync<CloseDownMeteringPoint>(InstantPattern.General
+        //             .Parse(request.EffectiveDate).Value).ConfigureAwait(false);
+        //
+        //     Assert.NotNull(command);
+        //     Assert.Equal(request.GsrnNumber, command?.GsrnNumber);
+        // }
+        //
+        // [Fact]
+        // public async Task Metering_point_is_closed_down()
+        // {
+        //     await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
+        //
+        //     var command = new CloseDownMeteringPoint(SampleData.GsrnNumber);
+        //     await SendCommandAsync(command).ConfigureAwait(false);
+        //
+        //     AssertMasterData()
+        //         .HasConnectionState(PhysicalState.ClosedDown);
+        // }
         [Fact]
-        public async Task The_close_down_activity_is_scheduled_when_process_is_started()
+        public async Task Metering_point_is_closed_down_when_due_date_has_transpired()
         {
             await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
-
             var request = CreateRequest();
             await ReceiveRequest(request).ConfigureAwait(false);
 
-            var command =
-                await GetScheduledCommandAsync<CloseDownMeteringPoint>(InstantPattern.General
-                    .Parse(request.EffectiveDate).Value).ConfigureAwait(false);
-
-            Assert.NotNull(command);
-            Assert.Equal(request.GsrnNumber, command?.GsrnNumber);
-        }
-
-        [Fact]
-        public async Task Metering_point_is_closed_down()
-        {
-            await CreatePhysicalConsumptionMeteringPointAsync().ConfigureAwait(false);
-
-            var command = new CloseDownMeteringPoint(SampleData.GsrnNumber);
-            await SendCommandAsync(command).ConfigureAwait(false);
+            await TimeHasPassed(request.EffectiveDate).ConfigureAwait(false);
 
             AssertMasterData()
                 .HasConnectionState(PhysicalState.ClosedDown);
@@ -167,6 +182,12 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CloseDown
                 TransactionId: SampleData.Transaction,
                 EffectiveDate: SampleData.EffectiveDate,
                 GsrnNumber: SampleData.GsrnNumber);
+        }
+
+        private Task TimeHasPassed(string now)
+        {
+            return GetService<IMediator>()
+                .Publish(new TimeHasPassed(InstantPattern.General.Parse(now).Value), CancellationToken.None);
         }
 
         private IRequestReceiver CreateReceiver()

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -254,7 +254,8 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                     typeof(OnMeteringPointConnected),
                     typeof(OnMeteringPointDisconnected),
                     typeof(OnMeteringPointReconnected),
-                    typeof(SetEnergySupplierHACK));
+                    typeof(SetEnergySupplierHACK),
+                    typeof(ProcessInternalCommandsOnTimeHasPassed));
 
             // Specific for test instead of using Application Insights package
             _container.Register(() => new TelemetryClient(new TelemetryConfiguration()), Lifestyle.Scoped);

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/MeteringPointFunctionAppFixture.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/MeteringPointFunctionAppFixture.cs
@@ -97,7 +97,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Fixtures
             ingestionHostSettings.Port = ++port;
 
             processingHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Processing\\bin\\{buildConfiguration}\\net5.0";
-            processingHostSettings.Functions = "QueueSubscriber ProcessInternalCommands";
+            processingHostSettings.Functions = "QueueSubscriber RaiseTimeHasPassedEvent";
             processingHostSettings.Port = ++port;
 
             outboxHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Outbox\\bin\\{buildConfiguration}\\net5.0";
@@ -114,7 +114,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Fixtures
 
             // Use "0 0 8 1 1 *", to do: 8:00 1. January ~ we must set this setting, but we do not want the trigger to run automatically, we want to trigger it manually
             outboxHostSettings.ProcessEnvironmentVariables.Add("ACTOR_MESSAGE_DISPATCH_TRIGGER_TIMER", "*/1 * * * * *");
-            processingHostSettings.ProcessEnvironmentVariables.Add("INTERNAL_COMMAND_PROCESSING_INTERVAL", "*/1 * * * * *");
+            processingHostSettings.ProcessEnvironmentVariables.Add("RAISE_TIME_HAS_PASSED_EVENT_SCHEDULE", "*/1 * * * * *");
 
             ingestionHostSettings.ProcessEnvironmentVariables.Add("AzureWebJobsStorage", "UseDevelopmentStorage=true");
             processingHostSettings.ProcessEnvironmentVariables.Add("AzureWebJobsStorage", "UseDevelopmentStorage=true");

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Functions/MeteringPointFunctionAppTests.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Functions/MeteringPointFunctionAppTests.cs
@@ -89,7 +89,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Function
 
             // Processing
             await AssertFunctionExecuted(Fixture.ProcessingHostManager, "QueueSubscriber").ConfigureAwait(false);
-            await AssertFunctionExecuted(Fixture.ProcessingHostManager, "ProcessInternalCommands").ConfigureAwait(false);
+            await AssertFunctionExecuted(Fixture.ProcessingHostManager, "RaiseTimeHasPassedEvent").ConfigureAwait(false);
 
             // Outbox
             await AssertFunctionExecuted(Fixture.OutboxHostManager, "OutboxWatcher").ConfigureAwait(false);


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
This PR adds a AZ function timer trigger to act as system timer, by emitting a `TimeHasPassed` event on scheduled basis. Interested services can subscribe to this event to trigger their on handling logic.
Therefore, the `ProcessInternalCommands` AZ function has been removed, and a notification handler has been added instead.

This decouples scheduled commands from the timer infrastructure, which improves the testability of business processes, since timer events can be emitted deterministically during test.

We will expand this concept later on, to remove the need for scheduled commands entirely.

<!--- Please leave a helpful description of the pull request here. --->