### PR TITLE
Moved correlation id to the header instead of body

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Functions/MeteringPointHttpTrigger.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Functions/MeteringPointHttpTrigger.cs
@@ -85,7 +85,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.Functions
             }
 
             await DispatchCommandsAsync(commands).ConfigureAwait(false);
-            return CreateOkResponse(request);
+            return CreateResponse(request, HttpStatusCode.Accepted);
         }
 
         private async Task<HttpResponseData> CreateForbiddenResponseAsync(HttpRequestData request, string errorMessage)
@@ -116,15 +116,6 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.Functions
                 .ConfigureAwait(false);
 
             return (isSucceeded, response, xmlElement);
-        }
-
-        private HttpResponseData CreateOkResponse(HttpRequestData request)
-        {
-            var response = CreateResponse(request, HttpStatusCode.Accepted);
-
-            response.Headers.Add("Content-Type", "text/plain; charset=utf-8");
-
-            return response;
         }
 
         private async Task DispatchCommandsAsync(IEnumerable<IInternalMarketDocument> commands)


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

Moved correlation id to the header as per our documentation.
Also made sure that we include it on all requests and not just the successful ones.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/green-energy-hub/issues/270
