### PR TITLE
Upgrade to .NET 6 and Functions v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -284,6 +284,7 @@ dotnet_diagnostic.CA1410.severity = warning
 dotnet_diagnostic.CA1415.severity = warning
 dotnet_diagnostic.CA1812.severity = suggestion
 dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1848.severity = suggestion
 dotnet_diagnostic.CA1900.severity = warning
 dotnet_diagnostic.CA1901.severity = warning
 dotnet_diagnostic.CA2002.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -520,3 +520,12 @@ dotnet_diagnostic.SX1309.severity = error
 
 dotnet_diagnostic.VSTHRD200.severity = none
 dotnet_diagnostic.CA1707.severity = none
+
+###############################
+# Code Style rules (IDE)      #
+###############################
+
+# See rules here: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -261,7 +261,10 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Analyzers/StyleCop rules
+###############################
+# .NET Analyzers              #
+###############################
+
 dotnet_diagnostic.CA1303.severity = suggestion
 dotnet_diagnostic.CA1715.severity = error
 dotnet_diagnostic.CA1001.severity = warning
@@ -329,7 +332,15 @@ dotnet_diagnostic.CA2238.severity = warning
 dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
+dotnet_diagnostic.CA2254.severity = suggestion
 dotnet_diagnostic.CS1591.severity = none
+
+###############################
+# StyleCop Analyzers          #
+###############################
+
+# See rules here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error
 dotnet_diagnostic.SA1001.severity = error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ on:
 jobs:
   ci_base:
     uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@6.0.0
-  
+
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_AZURE_FUNCTIONS_TOOLS: true
       USE_SQLLOCALDB_2019: true
     secrets:
@@ -47,50 +47,50 @@ jobs:
 
   ingestion_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj'
-      DOTNET_VERSION: '5.0.404'      
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: ingestion
 
   outbox_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: outbox
 
   processing_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: processing
 
   localmessagehub_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: localmessagehub
 
   webapi_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: webapi
 
   database_migration_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: databasemigration
 
   create_prerelease:

--- a/.github/workflows/client-publish.yml
+++ b/.github/workflows/client-publish.yml
@@ -45,7 +45,7 @@ env:
   # Conditions
   PUSH_PACKAGES: ${{ github.event_name != 'pull_request' }}
   # Tool versions
-  DOTNET_VERSION: '5.0.404'
+  DOTNET_VERSION: '6.0.201'
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
@@ -55,7 +55,7 @@ env:
 
 jobs:
   build_and_publish:
-    runs-on: windows-latest
+    runs-on: windows-2022
     name: Publish bundle to NuGet.org
 
     permissions:
@@ -63,17 +63,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@master
-
-      - name: Setup .NET 3.1 environment
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'
+        uses: actions/checkout@v3
 
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+        env:
+          DOTNET_INSTALL_DIR: 'C:\Program Files\dotnet'
 
       - name: Login to use Azure resources in integration tests
         if: ${{ env.AZURE_KEYVAULT_URL != '' && env.AZURE_SECRETS_KEYVAULT_URL != '' }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,31 +11,28 @@ on:
     types: [opened, synchronize, reopened]
 env:
   SOLUTION_PATH: 'source\Energinet.DataHub.MeteringPoints.sln'
-  DOTNET_VERSION: '5.0.x'
+  DOTNET_VERSION: '6.0.201'
   SONAR_PROJECTKEY: 'geh-metering-point'
   SOURCE_PATH_ON_BUILDMACHINE: 'D:\a\geh-metering-point\geh-metering-point\source' # We have to be speficic with this path to get around a .NET 5.0 issue in SonarCLoud
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
           java-version: 1.11
-    
-      - name: Setup .NET 3.1 environment
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '3.1.x'      
-      
+
       - name: Setup .NET ${{ env.DOTNET_VERSION }} environment
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-          
-      - uses: actions/checkout@v2
+        env:
+          DOTNET_INSTALL_DIR: 'C:\Program Files\dotnet'
+
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -44,6 +41,7 @@ jobs:
         run: |
           New-Item -Path .\.sonar\scanner -ItemType Directory
           dotnet tool update dotnet-sonarscanner --global
+
       - name: Build and analyze
         shell: powershell
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     See also: https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2019#search-scope
     -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56" >
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46" >
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -20,11 +20,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,13 +24,10 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+
         <!--
-        Additional settings for specific rules (e.g. SA1200 specify namespaces must be placed correctly, the json file then defines what "correctly" means)
-        See also [stylecop.json](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md)
+          Additional settings for specific rules (e.g. SA1200 specify namespaces must be placed correctly, the json file then defines what "correctly" means)
+          See also [stylecop.json](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/Configuration.md)
         -->
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)\stylecop.json" />
     </ItemGroup>

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -25,7 +25,7 @@ module "app_webapi" {
   dotnet_framework_version                  = "v6.0"
 
   app_settings                              = {
-    APPINSIGHTS_INSTRUMENTATIONKEY          = "${data.azurerm_key_vault_secret.appi_instrumentation_key.value}"
+    APPINSIGHTS_INSTRUMENTATIONKEY          = "${data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value}"
     B2C_TENANT_ID                           = "${data.azurerm_key_vault_secret.b2c_tenant_id.value}"
     FRONTEND_OPEN_ID_URL                    = "${data.azurerm_key_vault_secret.frontend_open_id_url.value}"
     FRONTEND_SERVICE_APP_ID                 = "${data.azurerm_key_vault_secret.frontend_service_app_id.value}"

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -11,48 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-resource "azurerm_app_service" "webapi" {
-  name                = "app-webapi-${lower(var.domain_name_short)}-${lower(var.environment_short)}-${lower(var.environment_instance)}"
-  resource_group_name = azurerm_resource_group.this.name
-  location            = azurerm_resource_group.this.location
-  app_service_plan_id = data.azurerm_key_vault_secret.plan_shared_id.value
+module "app_webapi" {
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/app-service?ref=5.8.0"
 
-  site_config {
-    dotnet_framework_version = "v6.0"
-    cors {
-      allowed_origins = ["*"]
+  name                                      = "webapi"
+  project_name                              = var.domain_name_short
+  environment_short                         = var.environment_short
+  environment_instance                      = var.environment_instance
+  resource_group_name                       = azurerm_resource_group.this.name
+  location                                  = azurerm_resource_group.this.location
+  app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  dotnet_framework_version                  = "v6.0"
+
+  app_settings                              = {
+    APPINSIGHTS_INSTRUMENTATIONKEY          = "${data.azurerm_key_vault_secret.appi_instrumentation_key.value}"
+    B2C_TENANT_ID                           = "${data.azurerm_key_vault_secret.b2c_tenant_id.value}"
+    FRONTEND_OPEN_ID_URL                    = "${data.azurerm_key_vault_secret.frontend_open_id_url.value}"
+    FRONTEND_SERVICE_APP_ID                 = "${data.azurerm_key_vault_secret.frontend_service_app_id.value}"
+  }
+
+  connection_strings = [
+    {
+      name  = "METERINGPOINT_DB_CONNECTION_STRING"
+      type  = "SQLAzure"
+      value = local.MS_CHARGE_DB_CONNECTION_STRING
     }
-  }
+  ]
 
-  app_settings = {
-    APPINSIGHTS_INSTRUMENTATIONKEY = "${data.azurerm_key_vault_secret.appi_instrumentation_key.value}"
-    B2C_TENANT_ID = "${data.azurerm_key_vault_secret.b2c_tenant_id.value}"
-    FRONTEND_OPEN_ID_URL = "${data.azurerm_key_vault_secret.frontend_open_id_url.value}"
-    FRONTEND_SERVICE_APP_ID = "${data.azurerm_key_vault_secret.frontend_service_app_id.value}"
-  }
-
-  connection_string {
-    name  = "METERINGPOINT_DB_CONNECTION_STRING"
-    type  = "SQLServer"
-    value = local.MS_METERING_POINT_CONNECTION_STRING
-  }
-
-  tags              = azurerm_resource_group.this.tags
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to tags, e.g. because a management agent
-      # updates these based on some ruleset managed elsewhere.
-      tags,
-    ]
-  }
+  tags                                      = azurerm_resource_group.this.tags
 }
 
 module "kvs_app_metering_point_webapi_base_url" {
   source        = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/key-vault-secret?ref=5.1.0"
 
   name          = "app-metering-point-webapi-base-url"
-  value         = "https://${azurerm_app_service.webapi.default_site_hostname}"
+  value         = "https://${module.app_webapi.default_site_hostname}"
   key_vault_id  = data.azurerm_key_vault.kv_shared_resources.id
 
   tags          = azurerm_resource_group.this.tags

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -35,7 +35,7 @@ module "app_webapi" {
     {
       name  = "METERINGPOINT_DB_CONNECTION_STRING"
       type  = "SQLAzure"
-      value = local.MS_CHARGE_DB_CONNECTION_STRING
+      value = local.MS_METERING_POINT_CONNECTION_STRING
     }
   ]
 

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -18,7 +18,7 @@ resource "azurerm_app_service" "webapi" {
   app_service_plan_id = data.azurerm_key_vault_secret.plan_shared_id.value
 
   site_config {
-    dotnet_framework_version = "v5.0"
+    dotnet_framework_version = "v6.0"
     cors {
       allowed_origins = ["*"]
     }

--- a/build/infrastructure/main/func-ingestion.tf
+++ b/build/infrastructure/main/func-ingestion.tf
@@ -21,7 +21,7 @@ module "func_ingestion" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
   log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {

--- a/build/infrastructure/main/func-ingestion.tf
+++ b/build/infrastructure/main/func-ingestion.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_ingestion" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "ingestion"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_ingestion" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values

--- a/build/infrastructure/main/func-localmessagehub.tf
+++ b/build/infrastructure/main/func-localmessagehub.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_localmessagehub" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "localmessagehub"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_localmessagehub" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values

--- a/build/infrastructure/main/func-localmessagehub.tf
+++ b/build/infrastructure/main/func-localmessagehub.tf
@@ -21,7 +21,7 @@ module "func_localmessagehub" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
   log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {

--- a/build/infrastructure/main/func-outbox.tf
+++ b/build/infrastructure/main/func-outbox.tf
@@ -21,7 +21,7 @@ module "func_outbox" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
   log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {

--- a/build/infrastructure/main/func-outbox.tf
+++ b/build/infrastructure/main/func-outbox.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_outbox" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "outbox"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_outbox" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values

--- a/build/infrastructure/main/func-processing.tf
+++ b/build/infrastructure/main/func-processing.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_processing" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.1.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "processing"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_processing" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values

--- a/build/infrastructure/main/func-processing.tf
+++ b/build/infrastructure/main/func-processing.tf
@@ -21,7 +21,7 @@ module "func_processing" {
   resource_group_name                       = azurerm_resource_group.this.name
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
-  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_instrumentation_key.value
+  application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
   log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -31,7 +31,7 @@ data "azurerm_key_vault_secret" "sb_domain_relay_transceiver_connection_string" 
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
 
-data "azurerm_key_vault_secret" "appi_instrumentation_key" {
+data "azurerm_key_vault_secret" "appi_shared_instrumentation_key" {
   name         = "appi-shared-instrumentation-key"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -135,3 +135,8 @@ data "azurerm_key_vault_secret" "plan_shared_id" {
   name         = "plan-shared-id"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
+
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}

--- a/docs/metering-point-client/release-notes/release-notes.md
+++ b/docs/metering-point-client/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # MeteringPoints.Client Release notes
 
+## Version 3.0.0
+
+.NET 6 and Azure Function v4 upgrades
+
 ## Version 0.0.1
 
 - Preparing packages for initial release.

--- a/source/Energinet.DataHub.MeteringPoints.Application/Energinet.DataHub.MeteringPoints.Application.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Energinet.DataHub.MeteringPoints.Application.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Application/Energinet.DataHub.MeteringPoints.Application.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Energinet.DataHub.MeteringPoints.Application.csproj
@@ -20,13 +20,13 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.90" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="2.0.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="2.0.0" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common" Version="2.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.App.Common.Security" Version="2.3.1" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter.Abstractions" Version="1.0.5" />
-    <PackageReference Include="FluentValidation" Version="10.3.0" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Helpers/DefaultUpgrader.cs
+++ b/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Helpers/DefaultUpgrader.cs
@@ -44,6 +44,7 @@ namespace Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.Helpers
                     Assembly.GetExecutingAssembly(),
                     x => !x.Contains(scriptsTest, StringComparison.Ordinal)))
                 .LogToConsole()
+                .WithExecutionTimeout(TimeSpan.FromMinutes(2))
                 .Build();
             var result = modelUpgrader.PerformUpgrade();
 
@@ -57,6 +58,7 @@ namespace Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.Helpers
                             x => x.Contains(scriptsTest, StringComparison.Ordinal))
                         .JournalTo(new NullJournal())
                         .LogToConsole()
+                        .WithExecutionTimeout(TimeSpan.FromMinutes(2))
                         .Build();
                 result = testDataUpgrader.PerformUpgrade();
             }

--- a/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
+++ b/source/Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp/Helpers/UpgradeFactory.cs
@@ -34,7 +34,8 @@ namespace Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.Helpers
                 .SqlDatabase(connectionString)
                 .WithScriptNameComparer(new ScriptComparer())
                 .WithScripts(new CustomScriptProvider(Assembly.GetExecutingAssembly(), scriptFilter))
-                .LogToConsole();
+                .LogToConsole()
+                .WithExecutionTimeout(TimeSpan.FromMinutes(2));
 
             if (isDryRun)
             {

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
@@ -26,7 +26,7 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Benchmarks/Energinet.DataHub.MeteringPoints.Benchmarks.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
@@ -67,7 +67,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client.Abstractions/Energinet.DataHub.MeteringPoints.Client.Abstractions.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MeteringPoints.Client.Abstractions</PackageId>
-    <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>MeteringPoints client abstractions library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>
@@ -72,5 +72,5 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
+
 </Project>

--- a/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
@@ -26,7 +26,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MeteringPoints.Client</PackageId>
-    <PackageVersion>2.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>3.0.0$(VersionSuffix)</PackageVersion>
     <Title>MeteringPoints client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Client/Energinet.DataHub.MeteringPoints.Client.csproj
@@ -63,7 +63,7 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -74,9 +74,9 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/Energinet.DataHub.MeteringPoints.Domain.csproj
@@ -30,8 +30,8 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="NodaTime" Version="3.0.5" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="NodaTime" Version="3.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Domain/MasterDataHandling/Consumption/Rules/ScheduledMeterReadingDateFormatRule.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Domain/MasterDataHandling/Consumption/Rules/ScheduledMeterReadingDateFormatRule.cs
@@ -49,8 +49,8 @@ namespace Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Consumption
 
         private static bool IsMonthAndDayValid(string monthAndDay)
         {
-            var month = int.Parse(monthAndDay.Substring(0, 2), NumberStyles.Integer, new NumberFormatInfo());
-            var day = int.Parse(monthAndDay.Substring(2, 2), NumberStyles.Integer, new NumberFormatInfo());
+            var month = int.Parse(monthAndDay.AsSpan(0, 2), NumberStyles.Integer, new NumberFormatInfo());
+            var day = int.Parse(monthAndDay.AsSpan(2, 2), NumberStyles.Integer, new NumberFormatInfo());
 
             if (month is < 1 or > 12)
             {

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
@@ -21,13 +21,13 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.20.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Core" Version="1.4.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/Energinet.DataHub.MeteringPoints.EntryPoints.Common.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/EmptyRequestPostProcessor.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/EmptyRequestPostProcessor.cs
@@ -14,12 +14,13 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using MediatR;
 using MediatR.Pipeline;
 
 namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
 {
     public class EmptyRequestPostProcessor<TRequest, TResponse> : IRequestPostProcessor<TRequest, TResponse>
-        where TRequest : notnull
+        where TRequest : notnull, IRequest<TResponse>
     {
         public Task Process(TRequest request, TResponse response, CancellationToken cancellationToken)
         {

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/NotificationHandlerTelemetryDecorator.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/NotificationHandlerTelemetryDecorator.cs
@@ -42,7 +42,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
         public async Task Handle(TNotification notification, CancellationToken cancellationToken)
         {
             var operationName = notification.GetType().Name;
-            _logger.LogInformation("Handle {notification}", operationName);
+            _logger.LogInformation("Handle {Notification}", operationName);
 
             var operation = _telemetryClient.StartOperation<DependencyTelemetry>(operationName);
             operation.Telemetry.Type = "Handler";

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/RequestHandlerTelemetryBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/RequestHandlerTelemetryBehavior.cs
@@ -23,7 +23,7 @@ using Microsoft.Extensions.Logging;
 namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
 {
     public class RequestHandlerTelemetryBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull
+        where TRequest : notnull, IRequest<TResponse>
     {
         private readonly TelemetryClient _telemetryClient;
         private readonly ILogger _logger;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/RequestHandlerTelemetryBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/MediatR/RequestHandlerTelemetryBehavior.cs
@@ -41,7 +41,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.MediatR
             if (next == null) throw new ArgumentNullException(nameof(next));
 
             var operationName = request.GetType().Name;
-            _logger.LogInformation("Handle {request}", operationName);
+            _logger.LogInformation("Handle {Request}", operationName);
             var operation = _telemetryClient.StartOperation<DependencyTelemetry>(operationName);
             operation.Telemetry.Type = "Handler";
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/SimpleInjector/SimpleInjectorScopedRequest.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/SimpleInjector/SimpleInjectorScopedRequest.cs
@@ -35,7 +35,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.SimpleInjector
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            using var scope = AsyncScopedLifestyle.BeginScope(_container);
             if (scope.Container == null) throw new InvalidOperationException("Scope doesn't contain a container.");
             context.InstanceServices = new SimpleInjectorServiceProviderAdapter(scope.Container);
             await next(context).ConfigureAwait(false);

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/SimpleInjector/SimpleInjectorScopedRequest.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Common/SimpleInjector/SimpleInjectorScopedRequest.cs
@@ -31,11 +31,12 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Common.SimpleInjector
             _container = container;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task Invoke(FunctionContext context, [NotNull] FunctionExecutionDelegate next)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
 
-            using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             if (scope.Container == null) throw new InvalidOperationException("Scope doesn't contain a container.");
             context.InstanceServices = new SimpleInjectorServiceProviderAdapter(scope.Container);
             await next(context).ConfigureAwait(false);

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
@@ -17,7 +17,7 @@ limitations under the License.
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
@@ -22,21 +22,21 @@ limitations under the License.
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.0.1" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp.SimpleInjector" Version="1.0.3" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp.SimpleInjector" Version="2.3.1" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.0" />
     <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.9" />
-    <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.9" />
+    <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.10" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter" Version="1.0.5" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter.Abstractions" Version="1.0.5" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter.SimpleInjector" Version="1.0.5" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.csproj
@@ -23,7 +23,7 @@ limitations under the License.
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.0.1" />
     <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp.SimpleInjector" Version="1.0.3" />
     <PackageReference Include="Energinet.DataHub.Core.Logging" Version="1.2.0" />
     <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.9" />
@@ -34,7 +34,7 @@ limitations under the License.
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
@@ -26,14 +26,14 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
@@ -31,7 +31,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.csproj
@@ -18,7 +18,7 @@ limitations under the License.
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <RootNamespace>Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub</RootNamespace>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Functions/BundleDequeuedQueueSubscriber.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Functions/BundleDequeuedQueueSubscriber.cs
@@ -47,7 +47,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.Functions
             await _localMessageHubClient.BundleDequeuedAsync(data).ConfigureAwait(false);
             await _unitOfWork.CommitAsync().ConfigureAwait(false);
 
-            _logger.LogInformation("Dequeued with correlation id: {correlationId}", _correlationContext.Id);
+            _logger.LogInformation("Dequeued with correlation id: {CorrelationId}", _correlationContext.Id);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Functions/RequestBundleQueueSubscriber.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Functions/RequestBundleQueueSubscriber.cs
@@ -50,7 +50,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub.Functions
             await _localMessageHubClient.CreateBundleAsync(data, _sessionContext.Id).ConfigureAwait(false);
             await _unitOfWork.CommitAsync().ConfigureAwait(false);
 
-            _logger.LogInformation("Dequeued with correlation id: {correlationId}", _correlationContext.Id);
+            _logger.LogInformation("Dequeued with correlation id: {CorrelationId}", _correlationContext.Id);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub/Program.cs
@@ -46,7 +46,6 @@ using Energinet.DataHub.MeteringPoints.Messaging.Bundling.AccountingPointCharact
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Confirm;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Generic;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Reject;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Common/OutboxMessageDispatcherTelemetryDecorator.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Common/OutboxMessageDispatcherTelemetryDecorator.cs
@@ -50,8 +50,8 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.Common
             var traceContext = TraceContext.Parse(message.Correlation);
             if (!traceContext.IsValid)
             {
-                _logger.LogWarning("Could not parse trace context for outbox message with id: {messageId} and correlation: {correlationId}", message.Id, message.Correlation);
-                _logger.LogInformation("Outbox dispatched: {messageType}", message.Type);
+                _logger.LogWarning("Could not parse trace context for outbox message with id: {MessageId} and correlation: {CorrelationId}", message.Id, message.Correlation);
+                _logger.LogInformation("Outbox dispatched: {MessageType}", message.Type);
 
                 await _decoratee.DispatchMessageAsync(message).ConfigureAwait(false);
                 return;
@@ -66,7 +66,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.Common
 
                 operation.Telemetry.Success = true;
 
-                _logger.LogInformation("Outbox dispatched: {messageType}", message.Type);
+                _logger.LogInformation("Outbox dispatched: {MessageType}", message.Type);
 
                 await _decoratee.DispatchMessageAsync(message).ConfigureAwait(false);
             }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -28,7 +28,6 @@ limitations under the License.
     <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="3.0.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.1" />
-    <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -25,7 +25,7 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="3.0.0" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients.SimpleInjector" Version="1.1.1" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients.Registration" Version="3.0.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.1" />
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -24,18 +24,18 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="1.0.13" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="3.0.0" />
     <PackageReference Include="Energinet.DataHub.Charges.Clients.SimpleInjector" Version="1.1.1" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
-    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.0" />
+    <PackageReference Include="Energinet.DataHub.MessageHub.Client.SimpleInjector" Version="1.6.1" />
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -20,7 +20,7 @@ limitations under the License.
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <TargetFramework>net6.0</TargetFramework>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/IntegrationEventDispatchers/RequestDefaultChargeLinksDispatcher.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/IntegrationEventDispatchers/RequestDefaultChargeLinksDispatcher.cs
@@ -16,7 +16,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.Charges.Clients.DefaultChargeLink;
-using Energinet.DataHub.Charges.Clients.Models;
+using Energinet.DataHub.Charges.Clients.DefaultChargeLink.Models;
 using Energinet.DataHub.MeteringPoints.Application.Integrations.ChargeLinks.Create;
 using MediatR;
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
@@ -47,6 +47,7 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf.Integration;
+using Energinet.DataHub.MeteringPoints.IntegrationEventContracts;
 using Energinet.DataHub.MeteringPoints.Messaging;
 using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Microsoft.EntityFrameworkCore;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
@@ -15,8 +15,8 @@
 using System;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
-using Energinet.DataHub.Charges.Clients.Models;
-using Energinet.DataHub.Charges.Clients.SimpleInjector;
+using Energinet.DataHub.Charges.Clients.DefaultChargeLink.Models;
+using Energinet.DataHub.Charges.Clients.Registration.DefaultChargeLink.SimpleInjector;
 using Energinet.DataHub.MessageHub.Client;
 using Energinet.DataHub.MessageHub.Client.SimpleInjector;
 using Energinet.DataHub.MeteringPoints.Application.Common;
@@ -47,7 +47,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf.Integration;
-using Energinet.DataHub.MeteringPoints.IntegrationEventContracts;
 using Energinet.DataHub.MeteringPoints.Messaging;
 using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Microsoft.EntityFrameworkCore;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Outbox/Program.cs
@@ -49,7 +49,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf.Integration;
 using Energinet.DataHub.MeteringPoints.IntegrationEventContracts;
 using Energinet.DataHub.MeteringPoints.Messaging;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using SimpleInjector;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
@@ -18,7 +18,7 @@ limitations under the License.
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <RootNamespace>Energinet.DataHub.MeteringPoints.EntryPoints.Processing</RootNamespace>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
@@ -25,16 +25,16 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="1.0.13" />
-    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Energinet.DataHub.Charges.Clients" Version="3.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.FunctionApp" Version="2.3.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.20.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Energinet.DataHub.MeteringPoints.EntryPoints.Processing.csproj
@@ -32,7 +32,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.0.13" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.ServiceBus" Version="4.2.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.1.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.3" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.3.0" OutputItemType="Analyzer" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.6.0" />
     <PackageReference Include="SimpleInjector" Version="5.3.2" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/ChargesResponseReceiver.cs
@@ -15,7 +15,7 @@
 using System;
 using System.Threading.Tasks;
 using Energinet.DataHub.Charges.Clients.DefaultChargeLink;
-using Energinet.DataHub.Charges.Clients.Models;
+using Energinet.DataHub.Charges.Clients.DefaultChargeLink.Models;
 using Energinet.DataHub.MeteringPoints.Application.Integrations.ChargeLinks.Create;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Correlation;
 using MediatR;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/QueueSubscriber.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Functions/QueueSubscriber.cs
@@ -52,7 +52,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Processing.Functions
 
             var result = await _mediator.Send(message).ConfigureAwait(false);
 
-            _logger.LogInformation("Dequeued with correlation id: {correlationId}", _correlationContext.Id);
+            _logger.LogInformation("Dequeued with correlation id: {CorrelationId}", _correlationContext.Id);
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Processing/Program.cs
@@ -90,7 +90,6 @@ using Energinet.DataHub.MeteringPoints.Messaging.Bundling.AccountingPointCharact
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Confirm;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Generic;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Reject;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using FluentValidation;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.EntityFrameworkCore;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.csproj
@@ -25,11 +25,11 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.App.WebApp.SimpleInjector" Version="1.0.3" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="Energinet.DataHub.Core.App.WebApp.SimpleInjector" Version="2.3.1" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
     <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="5.3.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <PackageId>Energinet.DataHub.MeteringPoints.EntryPoints.WebApi</PackageId>
     <Authors>Energinet.DataHub.MeteringPoints.EntryPoints.WebApi</Authors>

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Startup.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/Startup.cs
@@ -40,7 +40,6 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.Integration.IntegrationEve
 using Energinet.DataHub.MeteringPoints.Infrastructure.Outbox;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Serialization;
 using Energinet.DataHub.MeteringPoints.Infrastructure.Transport.Protobuf.Integration;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using FluentValidation;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;

--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/UserProvider.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.WebApi/UserProvider.cs
@@ -55,7 +55,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.WebApi
             }
             catch (Exception)
             {
-                _logger.LogInformation("GetUserAsync {userId}", userId);
+                _logger.LogInformation("GetUserAsync {UserId}", userId);
                 throw;
             }
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/ActorProvider.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/ActorProvider.cs
@@ -52,7 +52,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure
             }
             catch (Exception)
             {
-                _logger.LogInformation("GetActorAsync {actorId}", actorId);
+                _logger.LogInformation("GetActorAsync {ActorId}", actorId);
                 throw;
             }
         }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/BusinessProcessResultBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/BusinessProcessResultBehavior.cs
@@ -21,7 +21,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class BusinessProcessResultBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : IBusinessRequest
+        where TRequest : IBusinessRequest, MediatR.IRequest<TResponse>
         where TResponse : BusinessProcessResult
     {
         private readonly IBusinessProcessResultHandler<TRequest> _resultHandler;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/BusinessProcessResultBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/BusinessProcessResultBehavior.cs
@@ -21,7 +21,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class BusinessProcessResultBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : IBusinessRequest, MediatR.IRequest<TResponse>
+        where TRequest : IBusinessRequest, IRequest<TResponse>
         where TResponse : BusinessProcessResult
     {
         private readonly IBusinessProcessResultHandler<TRequest> _resultHandler;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InputValidationBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InputValidationBehavior.cs
@@ -25,7 +25,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class InputValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : IBusinessRequest
+        where TRequest : IBusinessRequest, MediatR.IRequest<TResponse>
         where TResponse : BusinessProcessResult
     {
         private readonly IValidator<TRequest> _validator;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InputValidationBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InputValidationBehavior.cs
@@ -25,7 +25,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class InputValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : IBusinessRequest, MediatR.IRequest<TResponse>
+        where TRequest : IBusinessRequest, IRequest<TResponse>
         where TResponse : BusinessProcessResult
     {
         private readonly IValidator<TRequest> _validator;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InternalCommandHandlingBehaviour.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InternalCommandHandlingBehaviour.cs
@@ -23,7 +23,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class InternalCommandHandlingBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-     where TRequest : InternalCommand
+     where TRequest : InternalCommand, MediatR.IRequest<TResponse>
     {
         private readonly MeteringPointContext _context;
         private readonly ISystemDateTimeProvider _systemDateTimeProvider;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InternalCommandHandlingBehaviour.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/InternalCommandHandlingBehaviour.cs
@@ -23,7 +23,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class InternalCommandHandlingBehaviour<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-     where TRequest : InternalCommand, MediatR.IRequest<TResponse>
+     where TRequest : InternalCommand, IRequest<TResponse>
     {
         private readonly MeteringPointContext _context;
         private readonly ISystemDateTimeProvider _systemDateTimeProvider;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ProcessOverviewBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ProcessOverviewBehavior.cs
@@ -24,7 +24,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class ProcessOverviewBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull, MediatR.IRequest<TResponse>
+        where TRequest : IRequest<TResponse>
     {
         private readonly ProcessExtractor<TRequest> _processExtractor;
         private readonly MeteringPointContext _meteringPointContext;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ProcessOverviewBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ProcessOverviewBehavior.cs
@@ -24,7 +24,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class ProcessOverviewBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull
+        where TRequest : notnull, MediatR.IRequest<TResponse>
     {
         private readonly ProcessExtractor<TRequest> _processExtractor;
         private readonly MeteringPointContext _meteringPointContext;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/UnitOfWorkBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/UnitOfWorkBehavior.cs
@@ -25,7 +25,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class UnitOfWorkBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull
+        where TRequest : notnull, MediatR.IRequest<TResponse>
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly MeteringPointContext _context;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/UnitOfWorkBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/UnitOfWorkBehavior.cs
@@ -25,7 +25,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class UnitOfWorkBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull, MediatR.IRequest<TResponse>
+        where TRequest : IRequest<TResponse>
     {
         private readonly IUnitOfWork _unitOfWork;
         private readonly MeteringPointContext _context;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ValidationReportsBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ValidationReportsBehavior.cs
@@ -19,7 +19,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class ValidationReportsBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull
+        where TRequest : notnull, MediatR.IRequest<TResponse>
     {
         public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ValidationReportsBehavior.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/BusinessRequestProcessing/Pipeline/ValidationReportsBehavior.cs
@@ -19,7 +19,7 @@ using MediatR;
 namespace Energinet.DataHub.MeteringPoints.Infrastructure.BusinessRequestProcessing.Pipeline
 {
     public class ValidationReportsBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
-        where TRequest : notnull, MediatR.IRequest<TResponse>
+        where TRequest : IRequest<TResponse>
     {
         public Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
         {

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/NodaTimeSqlMapper.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/DataAccess/NodaTimeSqlMapper.cs
@@ -62,7 +62,9 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess
 
                 if (conv?.CanConvertFrom(typeof(string)) == true)
                 {
+#pragma warning disable CS8605 // Unboxing a possibly null value.
                     return (Instant)conv.ConvertFromString(s);
+#pragma warning restore CS8605 // Unboxing a possibly null value.
                 }
             }
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -56,7 +56,7 @@ limitations under the License.
       <Access>Public</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net5.0\</OutputDir>
+      <OutputDir>obj\Debug\net6.0\</OutputDir>
       <Generator>MSBuild:Compile</Generator>
     </Protobuf>
   </ItemGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -21,16 +21,16 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.5.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.10.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.7.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.11.0" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter" Version="1.0.5" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter.Abstractions" Version="1.0.5" />
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.19.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.20.0" />
     <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Polly" Version="7.2.2" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -40,13 +40,13 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Tools" Version="2.37.0" PrivateAssets="All" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.45.0" PrivateAssets="All" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.0.0" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Energinet.DataHub.MeteringPoints.Infrastructure.csproj
@@ -31,6 +31,7 @@ limitations under the License.
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="SimpleInjector" Version="5.3.3" />
+    <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -39,7 +40,6 @@ limitations under the License.
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFrameworkCore.SqlServer.NodaTime" Version="5.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/IntegrationEvents/ChangeMasterData/MasterDataUpdated/MasterDataUpdatedIntegrationEvent.proto
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/Integration/IntegrationEvents/ChangeMasterData/MasterDataUpdated/MasterDataUpdatedIntegrationEvent.proto
@@ -53,14 +53,14 @@ message MasterDataUpdated {
     SM_PROFILED = 2;
     SM_NONPROFILED = 3;
   }
- 
+
  enum MeteringMethod {
    MM_NULL = 0;
    MM_PHYSICAL = 1;
    MM_VIRTUAL = 2;
    MM_CALCULATED = 3;
  }
-  
+
   enum MeterReadingPeriodicity {
     MRP_NULL = 0;
     MRP_HOURLY = 1;

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/CommandExecutor.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/CommandExecutor.cs
@@ -33,7 +33,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.InternalCommands
 
         public async Task ExecuteAsync(InternalCommand command, CancellationToken cancellationToken)
         {
-            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            using var scope = AsyncScopedLifestyle.BeginScope(_container);
             await scope.GetInstance<IMediator>().Send(command, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/CommandExecutor.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/InternalCommands/CommandExecutor.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Application.Common.Commands;
@@ -31,9 +32,10 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.InternalCommands
             _container = container ?? throw new ArgumentNullException(nameof(container));
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task ExecuteAsync(InternalCommand command, CancellationToken cancellationToken)
         {
-            using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             await scope.GetInstance<IMediator>().Send(command, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/.editorconfig
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
@@ -23,7 +23,6 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="2.2.0" />
-    <PackageReference Include="Energinet.DataHub.Charges.Clients.SimpleInjector" Version="1.1.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
@@ -22,22 +22,22 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="1.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="2.2.0" />
     <PackageReference Include="Energinet.DataHub.Charges.Clients.SimpleInjector" Version="1.1.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.11" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Energinet.DataHub.MeteringPoints.IntegrationTests.csproj
@@ -37,7 +37,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -96,7 +96,6 @@ using Energinet.DataHub.MeteringPoints.Messaging.Bundling.AccountingPointCharact
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Confirm;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Generic;
 using Energinet.DataHub.MeteringPoints.Messaging.Bundling.Reject;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using FluentAssertions;
 using FluentValidation;
 using MediatR;

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -497,7 +497,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
 
         protected async Task SendCommandAsync(object command, CancellationToken cancellationToken = default)
         {
-            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            using var scope = AsyncScopedLifestyle.BeginScope(_container);
             await scope.GetInstance<IMediator>().Send(command, cancellationToken).ConfigureAwait(false);
         }
 
@@ -531,13 +531,13 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
         {
             var request = Scenarios.CreateConsumptionMeteringPointCommand()
                 with
-                {
-                    MeteringMethod = MeteringMethod.Physical.Name,
-                    MeterNumber = "1",
-                    NetSettlementGroup = NetSettlementGroup.Zero.Name,
-                    ConnectionType = null,
-                    ScheduledMeterReadingDate = null,
-                };
+            {
+                MeteringMethod = MeteringMethod.Physical.Name,
+                MeterNumber = "1",
+                NetSettlementGroup = NetSettlementGroup.Zero.Name,
+                ConnectionType = null,
+                ScheduledMeterReadingDate = null,
+            };
             await SendCommandAsync(request).ConfigureAwait(false);
         }
 
@@ -558,24 +558,24 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
         {
             return TestUtils.CreateRequest()
                 with
-                {
-                    TransactionId = SampleData.Transaction,
-                    GsrnNumber = SampleData.GsrnNumber,
-                    EffectiveDate = CreateEffectiveDateAsOfToday().ToString(),
-                };
+            {
+                TransactionId = SampleData.Transaction,
+                GsrnNumber = SampleData.GsrnNumber,
+                EffectiveDate = CreateEffectiveDateAsOfToday().ToString(),
+            };
         }
 
         protected async Task CreateConsumptionMeteringPointInNetSettlementGroup6Async()
         {
             var request = Scenarios.CreateConsumptionMeteringPointCommand()
                 with
-                {
-                    EffectiveDate = CreateEffectiveDateAsOfToday().ToString(),
-                    MeteringMethod = MeteringMethod.Virtual.Name,
-                    NetSettlementGroup = NetSettlementGroup.Six.Name,
-                    ConnectionType = ConnectionType.Installation.Name,
-                    ScheduledMeterReadingDate = "0101",
-                };
+            {
+                EffectiveDate = CreateEffectiveDateAsOfToday().ToString(),
+                MeteringMethod = MeteringMethod.Virtual.Name,
+                NetSettlementGroup = NetSettlementGroup.Six.Name,
+                ConnectionType = ConnectionType.Installation.Name,
+                ScheduledMeterReadingDate = "0101",
+            };
             await SendCommandAsync(request).ConfigureAwait(false);
         }
 

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TestHost.cs
@@ -496,7 +496,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
 
         protected async Task SendCommandAsync(object command, CancellationToken cancellationToken = default)
         {
-            using var scope = AsyncScopedLifestyle.BeginScope(_container);
+            await using var scope = AsyncScopedLifestyle.BeginScope(_container);
             await scope.GetInstance<IMediator>().Send(command, cancellationToken).ConfigureAwait(false);
         }
 

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Tooling/MeteringPointDatabaseManager.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Tooling/MeteringPointDatabaseManager.cs
@@ -17,7 +17,6 @@ using System.Threading.Tasks;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Database;
 using Energinet.DataHub.MeteringPoints.ApplyDBMigrationsApp.Helpers;
 using Energinet.DataHub.MeteringPoints.Infrastructure.DataAccess;
-using EntityFrameworkCore.SqlServer.NodaTime.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 namespace Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TransportTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TransportTests.cs
@@ -35,7 +35,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             byte[]? bytes;
 
             // Send setup
-            await using var sendingContainer = new Container();
+            using var sendingContainer = new Container();
             sendingContainer.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             sendingContainer.Register<InProcessChannel>(Lifestyle.Singleton);
             sendingContainer.Register<Dispatcher>(Lifestyle.Transient);
@@ -58,7 +58,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             }
 
             // Receive setup
-            await using var receivingContainer = new Container();
+            using var receivingContainer = new Container();
             receivingContainer.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             receivingContainer.ReceiveProtobuf<MeteringPointEnvelope>(
                 config => config
@@ -67,7 +67,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             receivingContainer.Verify();
 
             // Receive scope
-            await using var scope = AsyncScopedLifestyle.BeginScope(receivingContainer);
+            using var scope = AsyncScopedLifestyle.BeginScope(receivingContainer);
             var messageExtractor = receivingContainer.GetRequiredService<MessageExtractor>();
             var message = await messageExtractor.ExtractAsync(bytes).ConfigureAwait(false);
             message.Should().BeOfType<MasterDataDocument>();

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TransportTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/TransportTests.cs
@@ -35,7 +35,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             byte[]? bytes;
 
             // Send setup
-            using var sendingContainer = new Container();
+            await using var sendingContainer = new Container();
             sendingContainer.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             sendingContainer.Register<InProcessChannel>(Lifestyle.Singleton);
             sendingContainer.Register<Dispatcher>(Lifestyle.Transient);
@@ -58,7 +58,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             }
 
             // Receive setup
-            using var receivingContainer = new Container();
+            await using var receivingContainer = new Container();
             receivingContainer.Options.DefaultScopedLifestyle = new AsyncScopedLifestyle();
             receivingContainer.ReceiveProtobuf<MeteringPointEnvelope>(
                 config => config
@@ -67,7 +67,7 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
             receivingContainer.Verify();
 
             // Receive scope
-            using var scope = AsyncScopedLifestyle.BeginScope(receivingContainer);
+            await using var scope = AsyncScopedLifestyle.BeginScope(receivingContainer);
             var messageExtractor = receivingContainer.GetRequiredService<MessageExtractor>();
             var message = await messageExtractor.ExtractAsync(bytes).ConfigureAwait(false);
             message.Should().BeOfType<MasterDataDocument>();

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/Energinet.DataHub.MeteringPoints.Messaging.csproj
@@ -22,7 +22,7 @@ limitations under the License.
 
   <ItemGroup>
     <PackageReference Include="Energinet.DataHub.MessageHub.Client" Version="1.9.1" />
-    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="MediatR" Version="10.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubClient.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubClient.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -56,6 +57,7 @@ namespace Energinet.DataHub.MeteringPoints.Messaging
             _systemDateTimeProvider = systemDateTimeProvider;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task CreateBundleAsync(byte[] request, string sessionId)
         {
             var bundleRequestDto = _requestBundleParser.Parse(request);
@@ -70,7 +72,7 @@ namespace Energinet.DataHub.MeteringPoints.Messaging
                 message.AddToBundle(bundleRequestDto.IdempotencyId);
             }
 
-            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bundle));
+            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bundle));
 
             var uri = await _storageHandler.AddStreamToStorageAsync(stream, bundleRequestDto).ConfigureAwait(false);
 

--- a/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubClient.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Messaging/LocalMessageHubClient.cs
@@ -70,7 +70,7 @@ namespace Energinet.DataHub.MeteringPoints.Messaging
                 message.AddToBundle(bundleRequestDto.IdempotencyId);
             }
 
-            await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bundle));
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(bundle));
 
             var uri = await _storageHandler.AddStreamToStorageAsync(stream, bundleRequestDto).ConfigureAwait(false);
 

--- a/source/Energinet.DataHub.MeteringPoints.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
@@ -25,21 +25,21 @@ limitations under the License.
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
     <PackageReference Include="Energinet.DataHub.Core.Schemas" Version="1.0.9" />
-    <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.9" />
+    <PackageReference Include="Energinet.DataHub.Core.SchemaValidation" Version="1.0.10" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter" Version="1.0.5" />
     <PackageReference Include="Energinet.DataHub.Core.XmlConversion.XmlConverter.Abstractions" Version="1.0.5" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.7" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="SimpleInjector" Version="5.3.2" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="SimpleInjector" Version="5.3.3" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.categories" Version="2.0.5" />
+    <PackageReference Include="xunit.categories" Version="2.0.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/Energinet.DataHub.MeteringPoints.Tests.csproj
@@ -39,7 +39,7 @@ limitations under the License.
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
@@ -42,7 +42,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub
         [Fact]
         public async Task Bundles_should_be_created_for_multiple_documents()
         {
-            await using var container = new Container();
+            using var container = new Container();
 
             container.UseMediatR()
                 .WithPipeline()

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/BundleCreatorTests.cs
@@ -42,7 +42,7 @@ namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub
         [Fact]
         public async Task Bundles_should_be_created_for_multiple_documents()
         {
-            using var container = new Container();
+            await using var container = new Container();
 
             container.UseMediatR()
                 .WithPipeline()

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/.editorconfig
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/IngestionFunctionAppFixture.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/IngestionFunctionAppFixture.cs
@@ -55,7 +55,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Fixtures
                 return;
 
             var buildConfiguration = GetBuildConfiguration();
-            hostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion\\bin\\{buildConfiguration}\\net5.0";
+            hostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion\\bin\\{buildConfiguration}\\net6.0";
         }
 
         /// <inheritdoc/>

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/MeteringPointFunctionAppFixture.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Fixtures/MeteringPointFunctionAppFixture.cs
@@ -92,19 +92,19 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Fixtures
 
             var buildConfiguration = GetBuildConfiguration();
             var port = 8000;
-            ingestionHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion\\bin\\{buildConfiguration}\\net5.0";
+            ingestionHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion\\bin\\{buildConfiguration}\\net6.0";
             ingestionHostSettings.Functions = "MeteringPoint";
             ingestionHostSettings.Port = ++port;
 
-            processingHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Processing\\bin\\{buildConfiguration}\\net5.0";
+            processingHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Processing\\bin\\{buildConfiguration}\\net6.0";
             processingHostSettings.Functions = "QueueSubscriber RaiseTimeHasPassedEvent";
             processingHostSettings.Port = ++port;
 
-            outboxHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Outbox\\bin\\{buildConfiguration}\\net5.0";
+            outboxHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.Outbox\\bin\\{buildConfiguration}\\net6.0";
             outboxHostSettings.Functions = "OutboxWatcher";
             outboxHostSettings.Port = ++port;
 
-            localMessageHubHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub\\bin\\{buildConfiguration}\\net5.0";
+            localMessageHubHostSettings.FunctionApplicationPath = $"..\\..\\..\\..\\Energinet.DataHub.MeteringPoints.EntryPoints.LocalMessageHub\\bin\\{buildConfiguration}\\net6.0";
             localMessageHubHostSettings.Functions = "BundleDequeuedQueueSubscriber RequestBundleQueueSubscriber";
             localMessageHubHostSettings.Port = ++port;
 

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests</AssemblyName>

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/MeteringPoints.EntryPoints.IntegrationTests.csproj
@@ -29,17 +29,17 @@ limitations under the License.
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.17.0" />
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="1.3.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="2.2.0" />
     <PackageReference Include="Energinet.DataHub.MessageHub.IntegrationTesting" Version="1.1.2" />
-    <PackageReference Include="FluentAssertions" Version="6.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Mocks/MessageHubMock.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Mocks/MessageHubMock.cs
@@ -55,8 +55,11 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Mocks
 
             _serviceBusClient ??= _serviceBusClientFactory.Create();
 
-            await using var sender = _serviceBusClient.CreateSender(_requestQueueName);
-            await sender.SendMessageAsync(serviceBusMessage).ConfigureAwait(false);
+            var sender = _serviceBusClient.CreateSender(_requestQueueName);
+            await using (sender.ConfigureAwait(false))
+            {
+                await sender.SendMessageAsync(serviceBusMessage).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/source/MeteringPoints.EntryPoints.IntegrationTests/Mocks/MessageHubMock.cs
+++ b/source/MeteringPoints.EntryPoints.IntegrationTests/Mocks/MessageHubMock.cs
@@ -55,7 +55,8 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.IntegrationTests.Mocks
 
             _serviceBusClient ??= _serviceBusClientFactory.Create();
 
-            var sender = _serviceBusClient.CreateSender(_requestQueueName);
+            await using var sender = _serviceBusClient.CreateSender(_requestQueueName);
+            await sender.SendMessageAsync(serviceBusMessage).ConfigureAwait(false);
             await using (sender.ConfigureAwait(false))
             {
                 await sender.SendMessageAsync(serviceBusMessage).ConfigureAwait(false);


### PR DESCRIPTION
## Description

Upgrade Metering Point to .NET 6 and Functions v4.
Update TF to use app service module (this will require us to rerun TF deploy as TF state will change).

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/259
