### PR TITLE
Fix for country code rule

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
@@ -41,6 +41,8 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create.Validation
             RuleFor(request => request.EffectiveDate).SetValidator(new EffectiveDateValidator());
             RuleFor(request => request.CountryCode)
                 .NotEmpty()
+                .WithState(createMeteringPoint =>
+                    new CountryCodeMandatoryValidationError(createMeteringPoint.GsrnNumber))
                 .SetValidator(new CountryCodeRule());
             RuleFor(request => request.AssetType)
                 .SetValidator(new AssetTypeRule()!)
@@ -83,7 +85,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create.Validation
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .WithState(createMeteringPoint =>
-                    new DisconnectionTypeMandatoryValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.DisconnectionType))
+                    new DisconnectionTypeMandatoryValidationError(createMeteringPoint.GsrnNumber))
                 .SetValidator(new DisconnectionTypeRule());
             RuleFor(request => request.ParentRelatedMeteringPoint)
                 .Must(value => GsrnNumber.CheckRules(value!).Success)

--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
@@ -40,6 +40,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create.Validation
                     new MeteringPointTypeValidationError(request.MeteringPointType ?? string.Empty));
             RuleFor(request => request.EffectiveDate).SetValidator(new EffectiveDateValidator());
             RuleFor(request => request.CountryCode)
+                .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .WithState(createMeteringPoint =>
                     new CountryCodeMandatoryValidationError(createMeteringPoint.GsrnNumber))

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CountryCodeMandatoryValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CountryCodeMandatoryValidationError.cs
@@ -16,12 +16,12 @@ using Energinet.DataHub.MeteringPoints.Domain.SeedWork;
 
 namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErrors
 {
-    public class DisconnectionTypeMandatoryValidationError : ValidationError
+    public class CountryCodeMandatoryValidationError : ValidationError
     {
-        public DisconnectionTypeMandatoryValidationError(string gsrnNumber)
+        public CountryCodeMandatoryValidationError(string gsrnNumber)
         {
             Code = "D02";
-            Message = $"Disconnection type for metering point {gsrnNumber} is missing (type E17/E18) or not allowed (other types)";
+            Message = $"Country code for metering point {gsrnNumber} is missing";
         }
     }
 }

--- a/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CountryCodeMandatoryValidationError.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Validation/ValidationErrors/CountryCodeMandatoryValidationError.cs
@@ -20,7 +20,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Validation.ValidationErro
     {
         public CountryCodeMandatoryValidationError(string gsrnNumber)
         {
-            Code = "D02";
+            Code = "E86";
             Message = $"Country code for metering point {gsrnNumber} is missing";
         }
     }

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/CreateTests.cs
@@ -347,6 +347,21 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
         }
 
         [Fact]
+        public async Task Should_reject_when_country_code_is_empty()
+        {
+            var invalidCountryCode = string.Empty;
+            var request = Scenarios.CreateDocument()
+                with
+                {
+                    CountryCode = invalidCountryCode,
+                };
+
+            await SendCommandAsync(request).ConfigureAwait(false);
+
+            AssertValidationError("E86");
+        }
+
+        [Fact]
         public async Task Effective_date_is_required()
         {
             var request = Scenarios.CreateDocument()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

Country code was throwing an exception if the field was empty. Turns out it was missing a custom state value.
Added the state and a test.

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/Internal-Repo/issues/165
