### PR TITLE
Disconnect should not be validated on child mps

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/CreateMeteringPoint.cs
@@ -43,7 +43,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create
             string? PowerPlant = null,
             string? LocationDescription = null,
             string? SettlementMethod = null,
-            string DisconnectionType = "",
+            string? DisconnectionType = "",
             string EffectiveDate = "",
             string? MeterNumber = "",
             string TransactionId = "",

--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
@@ -83,8 +83,11 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create.Validation
                 .Cascade(CascadeMode.Stop)
                 .NotEmpty()
                 .WithState(createMeteringPoint =>
-                    new DisconnectionTypeMandatoryValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.DisconnectionType))
-                .SetValidator(new DisconnectionTypeRule());
+                    new DisconnectionTypeMandatoryValidationError(createMeteringPoint.GsrnNumber, createMeteringPoint.DisconnectionType!))
+                .Unless(x => !(x.MeteringPointType.Equals(MeteringPointType.Consumption.Name, StringComparison.OrdinalIgnoreCase)
+                               || x.MeteringPointType.Equals(MeteringPointType.Production.Name, StringComparison.OrdinalIgnoreCase)
+                               || x.MeteringPointType.Equals(MeteringPointType.Exchange.Name, StringComparison.OrdinalIgnoreCase)))
+                .SetValidator(new DisconnectionTypeRule()!);
             RuleFor(request => request.ParentRelatedMeteringPoint)
                 .Must(value => GsrnNumber.CheckRules(value!).Success)
                 .WithState(request => new InvalidParentGsrnNumber())

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Scenarios.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Scenarios.cs
@@ -17,7 +17,6 @@ using System.Globalization;
 using Energinet.DataHub.MeteringPoints.Application;
 using Energinet.DataHub.MeteringPoints.Application.Create;
 using Energinet.DataHub.MeteringPoints.Application.MarketDocuments;
-using Energinet.DataHub.MeteringPoints.Domain;
 using Energinet.DataHub.MeteringPoints.Domain.BusinessProcesses;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.MeteringDetails;
@@ -133,10 +132,10 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                 ProductType: ProductType.EnergyActive.Name);
         }
 
-        internal static CreateMeteringPoint CreateCommand(MeteringPointType meteringPointType)
+        internal static CreateMeteringPoint CreateCommand(string meteringPointType)
         {
             return new CreateMeteringPoint(
-                MeteringPointType: meteringPointType.Name,
+                MeteringPointType: meteringPointType,
                 SampleData.Administrator,
                 SampleData.StreetName,
                 SampleData.BuildingNumber,
@@ -171,6 +170,11 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                 new ExchangeDetails(SampleData.MeteringGridArea, SampleData.MeteringGridArea),
                 UnitType: MeasurementUnitType.KWh.Name,
                 ProductType: ProductType.EnergyActive.Name);
+        }
+
+        internal static CreateMeteringPoint CreateCommand(MeteringPointType meteringPointType)
+        {
+            return CreateCommand(meteringPointType.Name);
         }
 
         internal static CreateMeteringPoint CreateExchangeReactiveEnergy()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

When validating disconnection type it should only be done for consumption, production and exchange meteringpoints 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
