### PR TITLE
Revert "Disconnect should not be validated on child mps"

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/CreateMeteringPoint.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/CreateMeteringPoint.cs
@@ -43,7 +43,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create
             string? PowerPlant = null,
             string? LocationDescription = null,
             string? SettlementMethod = null,
-            string? DisconnectionType = "",
+            string DisconnectionType = "",
             string EffectiveDate = "",
             string? MeterNumber = "",
             string TransactionId = "",

--- a/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Application/Create/Validation/RuleSet.cs
@@ -87,10 +87,7 @@ namespace Energinet.DataHub.MeteringPoints.Application.Create.Validation
                 .NotEmpty()
                 .WithState(createMeteringPoint =>
                     new DisconnectionTypeMandatoryValidationError(createMeteringPoint.GsrnNumber))
-                .Unless(x => !(x.MeteringPointType.Equals(MeteringPointType.Consumption.Name, StringComparison.OrdinalIgnoreCase)
-                               || x.MeteringPointType.Equals(MeteringPointType.Production.Name, StringComparison.OrdinalIgnoreCase)
-                               || x.MeteringPointType.Equals(MeteringPointType.Exchange.Name, StringComparison.OrdinalIgnoreCase)))
-                .SetValidator(new DisconnectionTypeRule()!);
+                .SetValidator(new DisconnectionTypeRule());
             RuleFor(request => request.ParentRelatedMeteringPoint)
                 .Must(value => GsrnNumber.CheckRules(value!).Success)
                 .WithState(request => new InvalidParentGsrnNumber())

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/SpecialMeteringPointTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/CreateMeteringPoints/SpecialMeteringPointTests.cs
@@ -15,14 +15,11 @@
 using System.Threading.Tasks;
 using Energinet.DataHub.MeteringPoints.Application.Create;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components;
-using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.MeteringDetails;
-using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Errors;
+using Energinet.DataHub.MeteringPoints.Domain.MeteringPoints;
 using Energinet.DataHub.MeteringPoints.Infrastructure.EDI;
 using Energinet.DataHub.MeteringPoints.IntegrationTests.Tooling;
 using Xunit;
 using Xunit.Categories;
-using MeteringPointType = Energinet.DataHub.MeteringPoints.Domain.MeteringPoints.MeteringPointType;
-using ReadingOccurrence = Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.ReadingOccurrence;
 
 namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
 {
@@ -62,27 +59,6 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests.CreateMeteringPoints
             await SendCommandAsync(request).ConfigureAwait(false);
 
             AssertValidationError("D53", DocumentType.RejectCreateMeteringPoint);
-        }
-
-        [Theory]
-        [InlineData(nameof(MeteringPointType.Consumption), true)]
-        [InlineData(nameof(MeteringPointType.Production), true)]
-        [InlineData(nameof(MeteringPointType.ConsumptionFromGrid), false)]
-        [InlineData(nameof(MeteringPointType.SupplyToGrid), false)]
-        [InlineData(nameof(MeteringPointType.Exchange), true)]
-        public async Task Consumption_from_grid_should_not_contain_disconnection_type(string meteringPointType, bool expectError)
-        {
-            var request = Scenarios.CreateCommand(meteringPointType)
-                with
-                {
-                    MeteringMethod = MeteringMethod.Physical.Name,
-                    DisconnectionType = null,
-                    MeterNumber = "pva30909290",
-                };
-
-            await SendCommandAsync(request).ConfigureAwait(false);
-
-            AssertValidationError("D02", expectError);
         }
 
         private static CreateMeteringPoint CreateCommand()

--- a/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Scenarios.cs
+++ b/source/Energinet.DataHub.MeteringPoints.IntegrationTests/Scenarios.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using Energinet.DataHub.MeteringPoints.Application;
 using Energinet.DataHub.MeteringPoints.Application.Create;
 using Energinet.DataHub.MeteringPoints.Application.MarketDocuments;
+using Energinet.DataHub.MeteringPoints.Domain;
 using Energinet.DataHub.MeteringPoints.Domain.BusinessProcesses;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components;
 using Energinet.DataHub.MeteringPoints.Domain.MasterDataHandling.Components.MeteringDetails;
@@ -132,10 +133,10 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                 ProductType: ProductType.EnergyActive.Name);
         }
 
-        internal static CreateMeteringPoint CreateCommand(string meteringPointType)
+        internal static CreateMeteringPoint CreateCommand(MeteringPointType meteringPointType)
         {
             return new CreateMeteringPoint(
-                MeteringPointType: meteringPointType,
+                MeteringPointType: meteringPointType.Name,
                 SampleData.Administrator,
                 SampleData.StreetName,
                 SampleData.BuildingNumber,
@@ -170,11 +171,6 @@ namespace Energinet.DataHub.MeteringPoints.IntegrationTests
                 new ExchangeDetails(SampleData.MeteringGridArea, SampleData.MeteringGridArea),
                 UnitType: MeasurementUnitType.KWh.Name,
                 ProductType: ProductType.EnergyActive.Name);
-        }
-
-        internal static CreateMeteringPoint CreateCommand(MeteringPointType meteringPointType)
-        {
-            return CreateCommand(meteringPointType.Name);
         }
 
         internal static CreateMeteringPoint CreateExchangeReactiveEnergy()


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

This reverts commit e6006928. The current solution leaks domain logic (and doesn't seem to work as expected).

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* https://github.com/Energinet-DataHub/Internal-Repo/issues/167
