### PR TITLE
Map new asset type

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/MasterDataDocumentXmlMappingConfiguration.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Infrastructure/EDI/XmlConverter/Mappings/MasterDataDocumentXmlMappingConfiguration.cs
@@ -198,6 +198,7 @@ namespace Energinet.DataHub.MeteringPoints.Infrastructure.EDI.XmlConverter.Mappi
                 "D17" => nameof(AssetType.DispatchableWindTurbines),
                 "D19" => nameof(AssetType.DieselCombustionEngine),
                 "D20" => nameof(AssetType.BioCombustionEngine),
+                "D98" => nameof(AssetType.NoTechnology),
                 "D99" => nameof(AssetType.UnknownTechnology),
 
                 _ => element.SourceValue,


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

The new D98 asset type had not been mapped, this PR will fix that. 

## References

<!--- Are there any issues, pull requests or similar that should be linked here? --->

* #0000
