### PR TITLE
Added logging for SRE team

### DIFF
--- a/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Functions/MeteringPointHttpTrigger.cs
+++ b/source/Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion/Functions/MeteringPointHttpTrigger.cs
@@ -71,6 +71,8 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.Functions
                 var result = _xmlDeserializer.Deserialize(element!);
                 var senderValidationResult = _xmlSenderValidator.ValidateSender(result.HeaderData.Sender);
 
+                _logger.LogInformation($"Received request of type {result.HeaderData.ProcessType} from sender {result.HeaderData.Sender.Id}");
+
                 if (!senderValidationResult.IsValid)
                     return await CreateForbiddenResponseAsync(request, senderValidationResult.ErrorMessage).ConfigureAwait(false);
 
@@ -122,6 +124,7 @@ namespace Energinet.DataHub.MeteringPoints.EntryPoints.Ingestion.Functions
         {
             foreach (var command in commands)
             {
+                _logger.LogInformation($"Dispatching command for internal processing");
                 await _dispatcher.DispatchAsync((IOutboundMessage)command).ConfigureAwait(false);
             }
         }

--- a/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/LocalMessageHubTests.cs
+++ b/source/Energinet.DataHub.MeteringPoints.Tests/LocalMessageHub/LocalMessageHubTests.cs
@@ -25,6 +25,7 @@ using Energinet.DataHub.MeteringPoints.Infrastructure.LocalMessageHub;
 using Energinet.DataHub.MeteringPoints.Messaging;
 using Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub.Mocks;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Categories;
 
@@ -61,11 +62,13 @@ namespace Energinet.DataHub.MeteringPoints.Tests.LocalMessageHub
                 new BundleCreatorMock(),
                 new SystemDateTimeProviderStub());
 
+            using var loggerFactory = new LoggerFactory();
             _localMessageHubDataAvailableClient = new LocalMessageHubDataAvailableClient(
                 _messageHubMessageRepository,
                 _dataAvailableNotificationOutboxDispatcher,
                 new MessageHubMessageFactory(new SystemDateTimeProviderStub()),
-                new CorrelationContext());
+                new CorrelationContext(),
+                new Logger<LocalMessageHubTests>(loggerFactory));
         }
 
         [Fact]


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

Added logging on:

- Request received
- Request forwarded to internal processing
- DataAvailableNotification to post office

To be used by SRE team for monitoring