### PR TITLE
Remove DOTNET_VERSION

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,13 +20,13 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@7.7.0
     secrets:
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
   dispatch_deployment_request:
     needs: publish_release
-    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@7.7.0
     with:
       CALLER_REPOSITORY_NAME: geh-metering-point
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-metering-point
@@ -35,10 +35,9 @@ jobs:
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
   update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@temporarily_disable_integration_test # TODO: Revert to next version when integration test issue is solved
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_AZURE_FUNCTIONS_TOOLS: true
       USE_SQLLOCALDB_2019: true
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,12 @@ on:
 
 jobs:
   ci_base:
-    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/ci-base.yml@7.7.0
 
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@temporarily_disable_integration_test # TODO: Revert to next version when integration test issue is solved
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MeteringPoints.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_AZURE_FUNCTIONS_TOOLS: true
       USE_SQLLOCALDB_2019: true
       PREPARE_OUTPUTS: true
@@ -40,7 +39,7 @@ jobs:
       AZURE_SECRETS_KEYVAULT_URL: ${{ secrets.AZURE_SECRETS_KEYVAULT_URL }}
 
   terraform_validate:
-    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/terraform-validate.yml@7.7.0
     with:
       TERRAFORM_WORKING_DIR_PATH: './build/infrastructure/main'
       TERRAFORM_VERSION: '1.2.2'
@@ -51,7 +50,7 @@ jobs:
       terraform_validate,
       dotnet_solution_ci
     ]
-    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.6.0
+    uses: Energinet-DataHub/.github/.github/workflows/create-prerelease.yml@7.7.0
     with:
       CALLER_REPOSITORY_PATH: Energinet-DataHub/geh-metering-point
     secrets:

--- a/.github/workflows/integration-events-publish.yml
+++ b/.github/workflows/integration-events-publish.yml
@@ -49,21 +49,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
-        with:
-          DOTNET_VERSION: '6.0.301'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/IntegrationEvents/IntegrationEvents.sln'
           USE_CODE_COVERAGE: 'false'
 
       - name: Pack IntegrationEvents project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/IntegrationEvents/source/IntegrationEvents/IntegrationEvents.csproj'
 
@@ -76,7 +74,7 @@ jobs:
             .github/workflows/integration-events.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}

--- a/.github/workflows/request-response-publish.yml
+++ b/.github/workflows/request-response-publish.yml
@@ -49,21 +49,19 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-checkout-repository@7.7.0
 
       - name: Setup dotnet and tools
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.5.0
-        with:
-          DOTNET_VERSION: '6.0.301'
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-setup-and-tools@7.7.0
 
       - name: Build and test solution
-        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/dotnet-solution-build-and-test@7.7.0
         with:
           SOLUTION_FILE_PATH: './source/RequestResponse/RequestResponse.sln'
           USE_CODE_COVERAGE: 'false'
 
       - name: Pack RequestResponse project
-        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-project-pack@7.7.0
         with:
           PROJECT_PATH: './source/RequestResponse/source/RequestResponse/RequestResponse.csproj'
 
@@ -76,7 +74,7 @@ jobs:
             .github/workflows/request-response-events.yml
 
       - name: Assert versions of NuGet packages and push them to NuGet.org
-        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.5.0
+        uses: Energinet-DataHub/.github/.github/actions/nuget-packages-assert-and-push@7.7.0
         with:
           PUSH_PACKAGES: ${{ env.PUSH_PACKAGES }}
           CONTENT_CHANGED: ${{ steps.changed-content.outputs.any_changed }}


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Reference: https://github.com/Energinet-DataHub/the-outlaws/issues/360