### PR TITLE
Set DB max size to 10 to comply with Tier policy

### DIFF
--- a/build/infrastructure/env/t-001/mssqldb-this_override.tf
+++ b/build/infrastructure/env/t-001/mssqldb-this_override.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 module "mssqldb_meteringpoint" {
   developer_ad_group_name     = var.developer_ad_group_name
-  max_size_gb                 = 8
+  max_size_gb                 = 10
 }


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description
Set DB max size to 10 in T001 to comply with T Tier policy
